### PR TITLE
Fix bug in async mode for generating attack methods

### DIFF
--- a/deepteam/red_teamer/red_teamer.py
+++ b/deepteam/red_teamer/red_teamer.py
@@ -340,7 +340,7 @@ class RedTeamer:
             input=simulated_attack.input,
             vulnerability=vulnerability,
             vulnerability_type=vulnerability_type,
-            attack_method=simulated_attack.attack_method,
+            attackMethod=simulated_attack.attack_method,
             riskCategory=getRiskCategory(vulnerability_type),
         )
 


### PR DESCRIPTION
Fixes bug in async mode where the `attack_method` in the `RedTeamingTestCase` object would be `None` because the code was attempting to use the raw field name instead of the pydantic alias

Before fix
```
  Error: 1 validation error for AttackMethodResult
attack_method
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```
