### PR TITLE
Fix #12 that crashed the tree attack

### DIFF
--- a/deepteam/attacks/multi_turn/tree_jailbreaking/tree_jailbreaking.py
+++ b/deepteam/attacks/multi_turn/tree_jailbreaking/tree_jailbreaking.py
@@ -351,12 +351,12 @@ class TreeJailbreaking(BaseAttack):
 
     def _generate_schema(self, prompt: str, schema: BaseModel):
         return generate_schema(
-            prompt, schema, self.using_native_model, self.simulator_model
+            prompt, schema, self.simulator_model
         )
 
     async def _a_generate_schema(self, prompt: str, schema: BaseModel):
         return await a_generate_schema(
-            prompt, schema, self.using_native_model, self.simulator_model
+            prompt, schema, self.simulator_model
         )
 
     def get_name(self) -> str:


### PR DESCRIPTION
Looks like the code is not updated from the deepeval version, which causes execution failure of the tree multi-turn attack. Fixed/updated the call for deepteam.