### PR TITLE
Fix OllamaModel initialize

### DIFF
--- a/deepteam/cli/model_callback.py
+++ b/deepteam/cli/model_callback.py
@@ -73,7 +73,7 @@ def load_model(spec: Union[str, Dict[str, Any], None]) -> DeepEvalBaseLLM:
 
     if provider == "ollama":
         return OllamaModel(
-            model_name=model_name,
+            model=model_name,
             base_url=spec.get("base_url", "http://localhost:11434"),
             temperature=temperature,
         )


### PR DESCRIPTION
Fixes issue #71 

To test, install ollama and the `huihui_ai/phi4-abliterated:14b` model. Clone the main repo, switch to the deepteam directory, and run:

`poetry install`

Run the existing deepteam code with the attached config_small.yaml file:

`deepteam run config_small.yaml`

Note that an error is produced.

Switch to the branch with the fix and re-run:

`deepteam run config_small.yaml`

Note that the error is no longer present and the tool runs as expected.

-------------------------------------------------
config_small.yaml:

```yaml
# Example DeepTeam Configuration
# This demonstrates the new YAML structure with improved organization

# Red teaming models (use standard models)
models:
  simulator:
    provider: ollama
    model: huihui_ai/phi4-abliterated:14b
    temperature: 0.7
  evaluation:
    provider: ollama
    model: huihui_ai/phi4-abliterated:14b
    temperature: 0.1

# Target system configuration (uses custom model)
target:
  purpose: "A helpful AI assistant"
  model:
    provider: ollama
    model: huihui_ai/phi4-abliterated:14b
    temperature: 0.5


# System configuration (renamed from options/simulation)
system_config:
  max_concurrent: 20                    # Maximum concurrent operations
  attacks_per_vulnerability_type: 3     # Number of attacks per vulnerability type
  run_async: true                       # Whether to run operations asynchronously
  ignore_errors: false                  # Whether to continue on errors

# Vulnerabilities to test
default_vulnerabilities:
  - name: "Bias"
    types: ["race", "gender"]

# Attack methods
attacks:
  - name: "Prompt Injection"
    weight: 1.0

  - name: "Leetspeak"
    weight: 0.8

  - name: "ROT-13"
    weight: 0.6

  - name: "Base64"
    weight: 0.7

  - name: "Roleplay"
    weight: 0.9
```
