### PR TITLE
Add CLI argument and config file option for saving results

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ deepteam run config.yaml -c 20 -a 5
 **Options:**
 - `-c, --max-concurrent`: Maximum concurrent operations (overrides config)
 - `-a, --attacks-per-vuln`: Number of attacks per vulnerability type (overrides config)
+- `-o, --output`: Path to the output folder for saving risk assessment results (overrides config)
 
 Use `deepteam --help` to see all available commands and options.
 
@@ -213,6 +214,7 @@ system_config:
   attacks_per_vulnerability_type: 3
   run_async: true
   ignore_errors: false
+  output_folder: "results"
 
 default_vulnerabilities:
   - name: "Bias"

--- a/deepteam/cli/main.py
+++ b/deepteam/cli/main.py
@@ -168,6 +168,12 @@ def run(
         "--attacks-per-vuln",
         help="Number of attacks per vulnerability type (overrides config)",
     ),
+    output_folder: str = typer.Option(
+        None,
+        "-o",
+        "--output",
+        help="Path to the output folder for saving risk assessment results (overrides config)",
+    ),
 ):
     """Run a red teaming execution based on a YAML configuration"""
     cfg = _load_config(config_file)
@@ -192,6 +198,11 @@ def run(
         attacks_per_vuln
         if attacks_per_vuln is not None
         else system_config.get("attacks_per_vulnerability_type", 1)
+    )
+    final_output_folder = (
+        output_folder
+        if output_folder is not None
+        else system_config.get("output_folder", None)
     )
 
     # Parse target configuration
@@ -254,6 +265,11 @@ def run(
     )
 
     red_teamer._print_risk_assessment()
+
+    # Save risk assessment if output folder is specified
+    if final_output_folder:
+        red_teamer.risk_assessment.save(to=final_output_folder)
+
     return risk
 
 

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -41,6 +41,7 @@ system_config:
   attacks_per_vulnerability_type: 3     # Number of attacks per vulnerability type
   run_async: true                       # Whether to run operations asynchronously
   ignore_errors: false                  # Whether to continue on errors
+  output_folder: "results"              # Folder to save results
 
 # Vulnerabilities to test
 default_vulnerabilities:


### PR DESCRIPTION
This PR adds both a CLI argument and a config file option for specifying the folder in which to save the assessment results (via the `risk_assessment.save(to="folder")` method).

As with other CLI arguments, if a CLI argument is given for the folder then it will overwrite the value in the yaml config file.

If not value is specified via CLI arugment or in the yaml config file, then the results will not be saved to disk.

This PR also updates examples and documentation to specify that these options for saving exists.

Tested the following cases:
- CLI argument only
- Config file option only
- CLI argument and Config file option (CLI overwrites config file, as expected)
- Neither CLI nor Config file option (results not saved)

All test cases worked as expected.