### PR TITLE
Add NoAttack class and fix for empty attacks (attack: []) in YAML files

### DIFF
--- a/deepteam/attacks/attack_simulator/attack_simulator.py
+++ b/deepteam/attacks/attack_simulator/attack_simulator.py
@@ -24,6 +24,12 @@ class SimulatedAttack(BaseModel):
     attack_method: Optional[str] = None
     error: Optional[str] = None
 
+class NoAttack:
+    def get_name(self):
+        return "NoAttack"
+
+    async def a_enhance(self, attack, *args, **kwargs):
+        return attack
 
 class AttackSimulator:
     model_callback: Union[CallbackType, None] = None
@@ -149,13 +155,14 @@ class AttackSimulator:
         ):
             async with semaphore:  # Throttling applied here
                 # Randomly sample an enhancement based on the distribution
-                attack_weights = [attack.weight for attack in attacks]
-                sampled_attack = random.choices(
-                    attacks, weights=attack_weights, k=1
-                )[0]
+                if not attacks:
+                    attack = NoAttack()
+                else:
+                    attack_weights = [attack.weight for attack in attacks]
+                    attack = random.choices(attacks, weights=attack_weights, k=1)[0]
 
                 result = await self.a_enhance_attack(
-                    attack=sampled_attack,
+                    attack=attack,
                     simulated_attack=baseline_attack,
                     ignore_errors=ignore_errors,
                 )


### PR DESCRIPTION
# Fix handling of empty attack list (`attack: []`) in YAML configuration to prevent runtime errors

This PR fixes a bug where specifying an empty list of attacks (`attack: []`) in the YAML config caused a runtime `TypeError` during attack enhancement.

## Problem

- When no attacks are specified, the code tried to call asynchronous enhancement on a non-existent attack object, leading to errors.

## Solution

- Added a `NoAttack` fallback class with a pass through async `a_enhance` method.
- Updated enhancement logic to use this fallback when the attack list is empty.

## Benefit

- The simulation now gracefully handles empty attack lists without errors.
- Allows users to safely specify `attack: []` in their YAML configs.
- In my case I wanted to see how an LLM performs without any special attacks - just running the base vulnerability templates. This PR enables running empty attack simulations.
