### PR TITLE
Fix uv sync commands

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,10 +20,10 @@ jobs:
 
       matrix:
         python:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     concurrency:
       # Cancel any currently running job or workflow in the same concurrency group.
@@ -54,7 +54,7 @@ jobs:
             **/uv.lock
 
       - name: Install dependencies
-        run: uv sync --locked --group build
+        run: uv sync --locked --extra build
 
       - name: Build package distribution
         run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
 
       matrix:
         python:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     concurrency:
       # Cancel any currently running job or workflow in the same concurrency group.
@@ -60,7 +60,7 @@ jobs:
             **/uv.lock
 
       - name: Install dependencies
-        run: uv sync --locked --group dev
+        run: uv sync --locked --extra dev
 
       - name: Run unit tests with coverage
         run: uv run --frozen pytest -svv

--- a/uv.lock
+++ b/uv.lock
@@ -501,7 +501,7 @@ wheels = [
 
 [[package]]
 name = "deepteam"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This change fixes the uv sync command as per the [uv docs](https://docs.astral.sh/uv/concepts/projects/sync/#syncing-extraneous-packages) because `dev` and `build` are optional dependencies