### PR TITLE
Resolves missing method references in `LinguisticConfusion.enhance()` that were causing `AttributeError` when using semantic manipulation attacks.

### DIFF
--- a/deepteam/attacks/single_turn/semantic_manipulation/semantic_manipulation.py
+++ b/deepteam/attacks/single_turn/semantic_manipulation/semantic_manipulation.py
@@ -22,9 +22,9 @@ class LinguisticConfusion(BaseAttack):
             LinguisticConfusionTemplate.enhance_semantic_ambiguity,
             LinguisticConfusionTemplate.enhance_syntactic_variation,
             LinguisticConfusionTemplate.enhance_contextual_reframing,
-            LinguisticConfusionTemplate.enhance_linguistic_obfuscation,
-            LinguisticConfusionTemplate.enhance_meaning_distortion,
-            LinguisticConfusionTemplate.enhance_universal_confusion_bridge,
+            LinguisticConfusionTemplate.enhance_obfuscation_decoding,  
+            LinguisticConfusionTemplate.enhance_pragmatic_inference,  
+            LinguisticConfusionTemplate.enhance_universal_translation, 
         ]
 
         for attempt in range(self.max_retries):


### PR DESCRIPTION
**Changes:**
- Replace non-existent methods with actual existing methods:
  - `enhance_linguistic_obfuscation` → `enhance_obfuscation_decoding`
  - `enhance_meaning_distortion` → `enhance_pragmatic_inference`  
  - `enhance_universal_confusion_bridge` → `enhance_universal_translation`

**Impact:** Semantic manipulation attacks now work without AttributeError.