### PR TITLE
fix: resolve CLI startup error with Roleplay attack initialization

### DIFF
--- a/deepteam/cli/main.py
+++ b/deepteam/cli/main.py
@@ -77,7 +77,8 @@ ATTACK_CLASSES = [
     SequentialJailbreak,
     BadLikertJudge,
 ]
-ATTACK_MAP = {cls().get_name(): cls for cls in ATTACK_CLASSES}
+
+ATTACK_MAP = {cls.__name__: cls for cls in ATTACK_CLASSES}
 
 
 def _build_vulnerability(cfg: dict, custom: bool):


### PR DESCRIPTION
## Root Cause
The CLI tries to instantiate all attack classes at import time to create mappings:
```python
ATTACK_MAP = {cls().get_name(): cls for cls in ATTACK_CLASSES}
```

However, the `Roleplay` class requires mandatory `persona` and `role` parameters, causing startup failure for all users.

## Solution
Change the mapping to use class names instead of instantiation:
```python
ATTACK_MAP = {cls.__name__: cls for cls in ATTACK_CLASSES}
```

## Benefits
- Fixes CLI startup for all users
- Maintains existing functionality  
- Simple, clean solution
- No breaking changes

## Related Issue
Closes #114