### PR TITLE
Specify prompt kwarg to all model calls

### DIFF
--- a/deepteam/attacks/attack_simulator/utils.py
+++ b/deepteam/attacks/attack_simulator/utils.py
@@ -23,11 +23,11 @@ def generate(
     """
     _, using_native_model = initialize_model(model=model)
     if using_native_model:
-        res, _ = model.generate(prompt, schema=schema)
+        res, _ = model.generate(prompt=prompt, schema=schema)
         return res
     else:
         try:
-            res = model.generate(prompt, schema=schema)
+            res = model.generate(prompt=prompt, schema=schema)
             data = trimAndLoadJson(res)
             return schema(**data)
         except TypeError:
@@ -59,11 +59,11 @@ async def a_generate(
     _, using_native_model = initialize_model(model=model)
 
     if using_native_model:
-        res, _ = await model.a_generate(prompt, schema=schema)
+        res, _ = await model.a_generate(prompt=prompt, schema=schema)
         return res
     else:
         try:
-            res = await model.a_generate(prompt, schema=schema)
+            res = await model.a_generate(prompt=prompt, schema=schema)
             data = trimAndLoadJson(res)
             return schema(**data)
         except TypeError:

--- a/deepteam/guardrails/guards/base_guard.py
+++ b/deepteam/guardrails/guards/base_guard.py
@@ -40,7 +40,7 @@ class BaseGuard(ABC):
         self.evaluation_cost = 0 if self.using_native_model else None
         if self.using_native_model:
             res, cost = self.model.generate(
-                guard_prompt, schema=SafetyLevelSchema
+                prompt=guard_prompt, schema=SafetyLevelSchema
             )
             self.evaluation_cost += cost
             self.safety_level = res.safety_level
@@ -71,7 +71,7 @@ class BaseGuard(ABC):
         self.evaluation_cost = 0 if self.using_native_model else None
         if self.using_native_model:
             res, cost = await self.model.a_generate(
-                guard_prompt, schema=SafetyLevelSchema
+                prompt=guard_prompt, schema=SafetyLevelSchema
             )
             self.evaluation_cost += cost
             self.safety_level = res.safety_level

--- a/deepteam/metrics/agentic/amnesia_assessment/amnesia_assessment.py
+++ b/deepteam/metrics/agentic/amnesia_assessment/amnesia_assessment.py
@@ -93,13 +93,15 @@ class AmnesiaAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = AmnesiaAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class AmnesiaAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = AmnesiaAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class AmnesiaAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class AmnesiaAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/boundary_violation/boundary_violation.py
+++ b/deepteam/metrics/agentic/boundary_violation/boundary_violation.py
@@ -93,13 +93,15 @@ class BoundaryViolationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BoundaryViolationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class BoundaryViolationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BoundaryViolationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class BoundaryViolationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class BoundaryViolationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/domain_validation/domain_validation.py
+++ b/deepteam/metrics/agentic/domain_validation/domain_validation.py
@@ -93,13 +93,15 @@ class DomainValidationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = DomainValidationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class DomainValidationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = DomainValidationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class DomainValidationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class DomainValidationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/escalation_success/escalation_success.py
+++ b/deepteam/metrics/agentic/escalation_success/escalation_success.py
@@ -93,13 +93,15 @@ class EscalationSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = EscalationSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class EscalationSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = EscalationSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class EscalationSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class EscalationSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/extraction_success/extraction_success.py
+++ b/deepteam/metrics/agentic/extraction_success/extraction_success.py
@@ -93,13 +93,15 @@ class ExtractionSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = ExtractionSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class ExtractionSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = ExtractionSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class ExtractionSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class ExtractionSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/goal_drift/goal_drift.py
+++ b/deepteam/metrics/agentic/goal_drift/goal_drift.py
@@ -93,13 +93,15 @@ class GoalDriftMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = GoalDriftTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class GoalDriftMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = GoalDriftTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class GoalDriftMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class GoalDriftMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/hallucination_detection/hallucination_detection.py
+++ b/deepteam/metrics/agentic/hallucination_detection/hallucination_detection.py
@@ -95,13 +95,15 @@ class HallucinationDetectionMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class HallucinationDetectionMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class HallucinationDetectionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -156,13 +162,13 @@ class HallucinationDetectionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/hierarchy_consistency/hierarchy_consistency.py
+++ b/deepteam/metrics/agentic/hierarchy_consistency/hierarchy_consistency.py
@@ -95,13 +95,15 @@ class HierarchyConsistencyMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class HierarchyConsistencyMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class HierarchyConsistencyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -156,13 +162,13 @@ class HierarchyConsistencyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/leakage_rate/leakage_rate.py
+++ b/deepteam/metrics/agentic/leakage_rate/leakage_rate.py
@@ -93,13 +93,15 @@ class LeakageRateMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = LeakageRateTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class LeakageRateMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = LeakageRateTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class LeakageRateMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class LeakageRateMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/manipulation_assessment/manipulation_assessment.py
+++ b/deepteam/metrics/agentic/manipulation_assessment/manipulation_assessment.py
@@ -95,13 +95,15 @@ class ManipulationAssessmentMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class ManipulationAssessmentMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class ManipulationAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -156,13 +162,13 @@ class ManipulationAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/misinterpretation/misinterpretation.py
+++ b/deepteam/metrics/agentic/misinterpretation/misinterpretation.py
@@ -93,13 +93,15 @@ class MisinterpretationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = MisinterpretationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class MisinterpretationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = MisinterpretationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class MisinterpretationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class MisinterpretationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/poisoning_assessment/poisoning_assessment.py
+++ b/deepteam/metrics/agentic/poisoning_assessment/poisoning_assessment.py
@@ -93,13 +93,15 @@ class PoisoningAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PoisoningAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class PoisoningAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PoisoningAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class PoisoningAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class PoisoningAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/subversion_success/subversion_success.py
+++ b/deepteam/metrics/agentic/subversion_success/subversion_success.py
@@ -93,13 +93,15 @@ class SubversionSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = SubversionSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class SubversionSuccessMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = SubversionSuccessTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class SubversionSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class SubversionSuccessMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/temporal_assessment/temporal_assessment.py
+++ b/deepteam/metrics/agentic/temporal_assessment/temporal_assessment.py
@@ -93,13 +93,15 @@ class TemporalAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = TemporalAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class TemporalAssessmentMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = TemporalAssessmentTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class TemporalAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class TemporalAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/unauthorized_execution/unauthorized_execution.py
+++ b/deepteam/metrics/agentic/unauthorized_execution/unauthorized_execution.py
@@ -95,13 +95,15 @@ class UnauthorizedExecutionMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class UnauthorizedExecutionMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class UnauthorizedExecutionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -156,13 +162,13 @@ class UnauthorizedExecutionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/agentic/verification_assessment/verification_assessment.py
+++ b/deepteam/metrics/agentic/verification_assessment/verification_assessment.py
@@ -95,13 +95,15 @@ class VerificationAssessmentMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class VerificationAssessmentMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class VerificationAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -156,13 +162,13 @@ class VerificationAssessmentMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/bfla/bfla.py
+++ b/deepteam/metrics/bfla/bfla.py
@@ -97,13 +97,15 @@ class BFLAMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BFLATemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -116,12 +118,14 @@ class BFLAMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BFLATemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -137,13 +141,15 @@ class BFLAMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -158,13 +164,13 @@ class BFLAMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/bias/bias.py
+++ b/deepteam/metrics/bias/bias.py
@@ -93,13 +93,15 @@ class BiasMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BiasTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -112,12 +114,14 @@ class BiasMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = BiasTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -132,13 +136,15 @@ class BiasMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -152,13 +158,13 @@ class BiasMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/bola/bola.py
+++ b/deepteam/metrics/bola/bola.py
@@ -98,13 +98,15 @@ class BOLAMetric(BaseRedTeamingMetric):
     async def a_generate_entities(self):
         prompt = BOLATemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Entities)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Entities
+            )
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
                 res: Entities = await self.model.a_generate(
-                    prompt, schema=Entities
+                    prompt=prompt, schema=Entities
                 )
                 return res.entities
             except TypeError:
@@ -115,12 +117,14 @@ class BOLAMetric(BaseRedTeamingMetric):
     def generate_entities(self):
         prompt = BOLATemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Entities)
+            res, cost = self.model.generate(prompt=prompt, schema=Entities)
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
-                res: Entities = self.model.generate(prompt, schema=Entities)
+                res: Entities = self.model.generate(
+                    prompt=prompt, schema=Entities
+                )
                 return res.entities
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class BOLAMetric(BaseRedTeamingMetric):
             entities=self.entities,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class BOLAMetric(BaseRedTeamingMetric):
             entities=self.entities,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/competitors/competitors.py
+++ b/deepteam/metrics/competitors/competitors.py
@@ -96,13 +96,15 @@ class CompetitorsMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = CompetitorsTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -115,12 +117,14 @@ class CompetitorsMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = CompetitorsTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class CompetitorsMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class CompetitorsMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/contracts/contracts.py
+++ b/deepteam/metrics/contracts/contracts.py
@@ -91,13 +91,15 @@ class ContractsMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -110,13 +112,13 @@ class ContractsMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/debug_access/debug_access.py
+++ b/deepteam/metrics/debug_access/debug_access.py
@@ -96,13 +96,15 @@ class DebugAccessMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -115,13 +117,13 @@ class DebugAccessMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/excessive_agency/excessive_agency.py
+++ b/deepteam/metrics/excessive_agency/excessive_agency.py
@@ -100,13 +100,15 @@ class ExcessiveAgencyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -121,13 +123,13 @@ class ExcessiveAgencyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/graphic_content/graphic_content.py
+++ b/deepteam/metrics/graphic_content/graphic_content.py
@@ -99,13 +99,15 @@ class GraphicMetric(BaseRedTeamingMetric):
             graphic_category=self.graphic_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class GraphicMetric(BaseRedTeamingMetric):
             graphic_category=self.graphic_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/hallucination/hallucination.py
+++ b/deepteam/metrics/hallucination/hallucination.py
@@ -98,13 +98,15 @@ class HallucinationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = HallucinationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -117,12 +119,14 @@ class HallucinationMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = HallucinationTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -137,13 +141,15 @@ class HallucinationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class HallucinationMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/harm/harm.py
+++ b/deepteam/metrics/harm/harm.py
@@ -99,13 +99,15 @@ class HarmMetric(BaseRedTeamingMetric):
             harm_category=self.harm_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class HarmMetric(BaseRedTeamingMetric):
             harm_category=self.harm_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/hijacking/hijacking.py
+++ b/deepteam/metrics/hijacking/hijacking.py
@@ -96,13 +96,15 @@ class HijackingMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = HijackingTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -115,12 +117,14 @@ class HijackingMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = HijackingTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class HijackingMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class HijackingMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/illegal_activity/illegal_activity.py
+++ b/deepteam/metrics/illegal_activity/illegal_activity.py
@@ -99,13 +99,15 @@ class IllegalMetric(BaseRedTeamingMetric):
             illegal_category=self.illegal_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class IllegalMetric(BaseRedTeamingMetric):
             illegal_category=self.illegal_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/imitation/imitation.py
+++ b/deepteam/metrics/imitation/imitation.py
@@ -98,13 +98,15 @@ class ImitationMetric(BaseRedTeamingMetric):
     async def a_generate_entities(self):
         prompt = ImitationTemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Entities)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Entities
+            )
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
                 res: Entities = await self.model.a_generate(
-                    prompt, schema=Entities
+                    prompt=prompt, schema=Entities
                 )
                 return res.entities
             except TypeError:
@@ -115,12 +117,14 @@ class ImitationMetric(BaseRedTeamingMetric):
     def generate_entities(self):
         prompt = ImitationTemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Entities)
+            res, cost = self.model.generate(prompt=prompt, schema=Entities)
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
-                res: Entities = self.model.generate(prompt, schema=Entities)
+                res: Entities = self.model.generate(
+                    prompt=prompt, schema=Entities
+                )
                 return res.entities
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class ImitationMetric(BaseRedTeamingMetric):
             entities=self.entities,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class ImitationMetric(BaseRedTeamingMetric):
             entities=self.entities,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/intellectual_property/intellectual_property.py
+++ b/deepteam/metrics/intellectual_property/intellectual_property.py
@@ -98,13 +98,15 @@ class IntellectualPropertyMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -119,12 +121,14 @@ class IntellectualPropertyMetric(BaseRedTeamingMetric):
             self.system_prompt
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -139,13 +143,15 @@ class IntellectualPropertyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -159,13 +165,13 @@ class IntellectualPropertyMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/misinformation/misinformation.py
+++ b/deepteam/metrics/misinformation/misinformation.py
@@ -99,13 +99,15 @@ class MisinformationMetric(BaseRedTeamingMetric):
             misinformation_category=self.misinformation_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class MisinformationMetric(BaseRedTeamingMetric):
             misinformation_category=self.misinformation_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/overreliance/overreliance.py
+++ b/deepteam/metrics/overreliance/overreliance.py
@@ -96,13 +96,15 @@ class OverrelianceMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = OverrelianceTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -115,12 +117,14 @@ class OverrelianceMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = OverrelianceTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class OverrelianceMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class OverrelianceMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/personal_safety/personal_safety.py
+++ b/deepteam/metrics/personal_safety/personal_safety.py
@@ -99,13 +99,15 @@ class SafetyMetric(BaseRedTeamingMetric):
             safety_category=self.safety_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class SafetyMetric(BaseRedTeamingMetric):
             safety_category=self.safety_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/pii/pii.py
+++ b/deepteam/metrics/pii/pii.py
@@ -102,13 +102,15 @@ class PIIMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PIITemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -121,12 +123,14 @@ class PIIMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PIITemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class PIIMetric(BaseRedTeamingMetric):
     async def a_generate_entities(self) -> List[str]:
         prompt = PIITemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Entities)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Entities
+            )
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
                 res: Entities = await self.model.a_generate(
-                    prompt, schema=Entities
+                    prompt=prompt, schema=Entities
                 )
                 return res.entities
             except TypeError:
@@ -153,12 +159,14 @@ class PIIMetric(BaseRedTeamingMetric):
     def generate_entities(self) -> List[str]:
         prompt = PIITemplate.extract_entities(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Entities)
+            res, cost = self.model.generate(prompt=prompt, schema=Entities)
             self.evaluation_cost += cost
             return res.entities
         else:
             try:
-                res: Entities = self.model.generate(prompt, schema=Entities)
+                res: Entities = self.model.generate(
+                    prompt=prompt, schema=Entities
+                )
                 return res.entities
             except TypeError:
                 res = self.model.generate(prompt)
@@ -175,13 +183,15 @@ class PIIMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -197,13 +207,13 @@ class PIIMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/prompt_extraction/prompt_extraction.py
+++ b/deepteam/metrics/prompt_extraction/prompt_extraction.py
@@ -96,13 +96,15 @@ class PromptExtractionMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PromptExtractionTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -115,12 +117,14 @@ class PromptExtractionMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = PromptExtractionTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class PromptExtractionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class PromptExtractionMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/rbac/rbac.py
+++ b/deepteam/metrics/rbac/rbac.py
@@ -104,13 +104,15 @@ class RBACMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -125,13 +127,13 @@ class RBACMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -144,13 +146,15 @@ class RBACMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = RBACTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -163,12 +167,14 @@ class RBACMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = RBACTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepteam/metrics/shell_injection/shell_injection.py
+++ b/deepteam/metrics/shell_injection/shell_injection.py
@@ -96,13 +96,15 @@ class ShellInjectionMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -115,13 +117,13 @@ class ShellInjectionMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/sql_injection/sql_injection.py
+++ b/deepteam/metrics/sql_injection/sql_injection.py
@@ -94,13 +94,15 @@ class SQLInjectionMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -113,13 +115,13 @@ class SQLInjectionMetric(BaseRedTeamingMetric):
             input=test_case.input, actual_output=test_case.actual_output
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/ssrf/ssrf.py
+++ b/deepteam/metrics/ssrf/ssrf.py
@@ -96,13 +96,15 @@ class SSRFMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = SSRFTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Purpose)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=Purpose
+            )
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
                 res: Purpose = await self.model.a_generate(
-                    prompt, schema=Purpose
+                    prompt=prompt, schema=Purpose
                 )
                 return res.purpose
             except TypeError:
@@ -115,12 +117,14 @@ class SSRFMetric(BaseRedTeamingMetric):
             return self.purpose
         prompt = SSRFTemplate.extract_purpose(self.system_prompt)
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Purpose)
+            res, cost = self.model.generate(prompt=prompt, schema=Purpose)
             self.evaluation_cost += cost
             return res.purpose
         else:
             try:
-                res: Purpose = self.model.generate(prompt, schema=Purpose)
+                res: Purpose = self.model.generate(
+                    prompt=prompt, schema=Purpose
+                )
                 return res.purpose
             except TypeError:
                 res = self.model.generate(prompt)
@@ -136,13 +140,15 @@ class SSRFMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -157,13 +163,13 @@ class SSRFMetric(BaseRedTeamingMetric):
             purpose=self.purpose,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:

--- a/deepteam/metrics/toxicity/toxicity.py
+++ b/deepteam/metrics/toxicity/toxicity.py
@@ -99,13 +99,15 @@ class ToxicityMetric(BaseRedTeamingMetric):
             toxicity_category=self.toxicity_category,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+            res, cost = await self.model.a_generate(
+                prompt=prompt, schema=ReasonScore
+            )
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = await self.model.a_generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:
@@ -120,13 +122,13 @@ class ToxicityMetric(BaseRedTeamingMetric):
             toxicity_category=self.toxicity_category,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=ReasonScore)
+            res, cost = self.model.generate(prompt=prompt, schema=ReasonScore)
             self.evaluation_cost += cost
             return res.score, res.reason
         else:
             try:
                 res: ReasonScore = self.model.generate(
-                    prompt, schema=ReasonScore
+                    prompt=prompt, schema=ReasonScore
                 )
                 return res.score, res.reason
             except TypeError:


### PR DESCRIPTION

Some models may not support the prompt as a positional and only allow it as a kwarg.

The main case for this is when you are trying to inherit from `DeepEvalBaseLLM`. It is not a valid override to add a positional `prompt` argument as `DeepEvalBaseLLM` does not have it, yet DeepTeam is assuming that the first positional argument is present. This is making every generate call inherently unsafe and not interoperable with DeepEval models.

This problem also exists in DeepEval as it also expects a `prompt` positional despite it not existing in the base class, but that needs to be done in a PR in that repo as well.

The alternative to this PR is to make `DeepEvalBaseLLM` have a `prompt` positional argument so that clients can override it safely, but that would be a breaking change.
