### PR TITLE
Fixed sidebar headings not visible clearly in Darkmode

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -376,7 +376,7 @@ html[data-theme="light"] .sidebar-icon {
 }
 
 html[data-theme="dark"] .sidebar-icon {
-  color: black;
+  color: white;
   font-weight: 500;
 }
 
@@ -430,6 +430,13 @@ html[data-theme="dark"] .menu {
 
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link:first-of-type {
   color: black; // Example: orange text
+  font-weight: 600 !important;
+  font-size: 15px;
+}
+
+/* Dark mode */
+[data-theme='dark'] .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link:first-of-type {
+  color: white; // or any high-contrast color
   font-weight: 600 !important;
   font-size: 15px;
 }


### PR DESCRIPTION
Before (Collapsable section headings are not at all visible in Dark Mode)

<img width="784" height="338" alt="image" src="https://github.com/user-attachments/assets/cc58349f-dfe6-419c-b86c-84b0084107d4" />



After

<img width="782" height="332" alt="image" src="https://github.com/user-attachments/assets/f3005d96-653b-4b47-b9d7-b2a3a7b75cc9" />

