### PR TITLE
Update red-teaming-introduction.mdx

### DIFF
--- a/docs/docs/red-teaming-introduction.mdx
+++ b/docs/docs/red-teaming-introduction.mdx
@@ -422,7 +422,7 @@ The `red_team()` function is a quick and easy way to red team LLM systems in a s
 To use the `RedTeamer`, instantiate a `RedTeamer` instance.
 
 ```python
-from deepteam.red_teaming import RedTeamer
+from deepteam.red_teamer import RedTeamer
 
 red_teamer = RedTeamer()
 ```


### PR DESCRIPTION
docs: correct import statement

The example was importing RedTeamer from wrong module.