### PR TITLE
fix(attacks): Fix context propagation in CrescendoJailbreaking

### DIFF
--- a/deepteam/attacks/multi_turn/crescendo_jailbreaking/crescendo_jailbreaking.py
+++ b/deepteam/attacks/multi_turn/crescendo_jailbreaking/crescendo_jailbreaking.py
@@ -207,14 +207,12 @@ class CrescendoJailbreaking(BaseMultiTurnAttack):
                     turns.append(
                         RTTurn(
                             role="assistant",
-                            content=assistant_response,
+                            content=last_response,
                             turn_level_attack=turn_level_attack.get_name(),
                         )
                     )
                 else:
-                    turns.append(
-                        RTTurn(role="assistant", content=assistant_response)
-                    )
+                    turns.append(RTTurn(role="assistant", content=last_response))
 
                 is_refusal, refusal_rationale = self.get_refusal_score(
                     last_response, current_attack, vulnerability_data
@@ -380,14 +378,12 @@ class CrescendoJailbreaking(BaseMultiTurnAttack):
                     turns.append(
                         RTTurn(
                             role="assistant",
-                            content=assistant_response,
+                            content=last_response,
                             turn_level_attack=turn_level_attack.get_name(),
                         )
                     )
                 else:
-                    turns.append(
-                        RTTurn(role="assistant", content=assistant_response)
-                    )
+                    turns.append(RTTurn(role="assistant", content=last_response))
 
                 is_refusal, refusal_rationale = await self.a_get_refusal_score(
                     last_response, current_attack, vulnerability_data


### PR DESCRIPTION
Fixed a bug where the multi-round conversation results of the Crescendo jailbreaking attack were not being passed to RTTurn.