### PR TITLE
Fix command syntax for setting Ollama model

### DIFF
--- a/docs/docs/red-teaming-introduction.mdx
+++ b/docs/docs/red-teaming-introduction.mdx
@@ -284,16 +284,16 @@ ollama run deepseek-r1:1.5b
 
 :::
 
-To use **Ollama** models for your red teaming, run `deepeval set-ollama <model>` in your CLI. For example:
+To use **Ollama** models for your red teaming, run `deepeval set-ollama --model <model>` in your CLI. For example:
 
 ```bash
-deepeval set-ollama deepseek-r1:1.5b
+deepeval set-ollama --model deepseek-r1:1.5b
 ```
 
 Optionally, you can specify the **base URL** of your local Ollama model instance if you've defined a custom port. The default base URL is set to `http://localhost:11434`.
 
 ```bash
-deepeval set-ollama deepseek-r1:1.5b \
+deepeval set-ollama --model deepseek-r1:1.5b \
     --base-url="http://localhost:11434"
 ```
 


### PR DESCRIPTION
--model missing from parameter, else will get following error 

[33mUsage: [0mdeepeval set-ollama [OPTIONS]
[2mTry [0m[2;34m'deepeval set-ollama [0m[1;2;34m-[0m[1;2;34m-help[0m[2;34m'[0m[2m for help.[0m [31m╭─[0m[31m Error [0m[31m─────────────────────────────────────────────────────────────────────[0m[31m─╮[0m
[31m│[0m Got unexpected extra argument (deepseek-r1:8b)                               [31m│[0m
[31m╰──────────────────────────────────────────────────────────────────────────────╯[0m