### PR TITLE
Fix circular import in risks.py causing NameError on VulnerabilityType

### DIFF
--- a/deepteam/risks/risks.py
+++ b/deepteam/risks/risks.py
@@ -1,7 +1,7 @@
-from enum import Enum
-from typing import Dict
+from __future__ import annotations
 
-from deepteam.vulnerabilities.types import *
+from enum import Enum
+from typing import Dict, Union
 
 
 class LLMRiskCategories(Enum):
@@ -13,9 +13,31 @@ class LLMRiskCategories(Enum):
 
 
 def getRiskCategory(
-    vulnerability_type: Union[VulnerabilityType, Enum],
+    vulnerability_type: Union[Enum],
 ) -> LLMRiskCategories:
-    risk_category_map: Dict[VulnerabilityType, LLMRiskCategories] = {
+    # Import lazily to avoid circular import with vulnerabilities.types
+    # (types.py -> exploit_tool_agent -> risks.py -> types.py)
+    from deepteam.vulnerabilities.bias import BiasType
+    from deepteam.vulnerabilities.toxicity import ToxicityType
+    from deepteam.vulnerabilities.illegal_activity import IllegalActivityType
+    from deepteam.vulnerabilities.graphic_content import GraphicContentType
+    from deepteam.vulnerabilities.personal_safety import PersonalSafetyType
+    from deepteam.vulnerabilities.misinformation import MisinformationType
+    from deepteam.vulnerabilities.excessive_agency import ExcessiveAgencyType
+    from deepteam.vulnerabilities.robustness import RobustnessType
+    from deepteam.vulnerabilities.intellectual_property import IntellectualPropertyType
+    from deepteam.vulnerabilities.competition import CompetitionType
+    from deepteam.vulnerabilities.prompt_leakage import PromptLeakageType
+    from deepteam.vulnerabilities.pii_leakage import PIILeakageType
+    from deepteam.vulnerabilities.bfla.types import BFLAType
+    from deepteam.vulnerabilities.bola.types import BOLAType
+    from deepteam.vulnerabilities.rbac import RBACType
+    from deepteam.vulnerabilities.debug_access.types import DebugAccessType
+    from deepteam.vulnerabilities.shell_injection.types import ShellInjectionType
+    from deepteam.vulnerabilities.sql_injection.types import SQLInjectionType
+    from deepteam.vulnerabilities.ssrf.types import SSRFType
+
+    risk_category_map: Dict[Enum, LLMRiskCategories] = {
         # Responsible AI
         **{bias: LLMRiskCategories.RESPONSIBLE_AI for bias in BiasType},
         **{


### PR DESCRIPTION
The module-level `from deepteam.vulnerabilities.types import *` caused a circular import chain: types.py -> exploit_tool_agent -> risks.py -> types.py (incomplete). Since types.py was only partially loaded, VulnerabilityType was not yet defined.

Fix by moving imports inside getRiskCategory() function body (lazy imports). By the time the function is called at runtime, all modules are fully loaded.