### PR TITLE
fix: replay model_callback for multi-turn attacks when reuse_simulated_test_cases=True

### DIFF
--- a/deepteam/red_team.py
+++ b/deepteam/red_team.py
@@ -20,6 +20,7 @@ def red_team(
     async_mode: bool = True,
     max_concurrent: int = 10,
     target_purpose: Optional[str] = None,
+    reuse_simulated_test_cases: bool = False,
 ):
     red_teamer = RedTeamer(
         async_mode=async_mode,
@@ -37,5 +38,6 @@ def red_team(
         framework=framework,
         attacks_per_vulnerability_type=attacks_per_vulnerability_type,
         ignore_errors=ignore_errors,
+        reuse_simulated_test_cases=reuse_simulated_test_cases,
     )
     return risk_assessment

--- a/deepteam/red_teamer/red_teamer.py
+++ b/deepteam/red_teamer/red_teamer.py
@@ -259,6 +259,7 @@ class RedTeamer:
                                 vulnerability_type,
                                 test_cases,
                                 ignore_errors=ignore_errors,
+                                reuse_simulated_test_cases=reuse_simulated_test_cases,
                             )
                             red_teaming_test_cases.extend(rt_test_cases)
 
@@ -452,6 +453,7 @@ class RedTeamer:
                                     vulnerability_type,
                                     attacks,
                                     ignore_errors=ignore_errors,
+                                    reuse_simulated_test_cases=reuse_simulated_test_cases,
                                 )
                             )
                             red_teaming_test_cases.extend(test_cases)
@@ -490,6 +492,7 @@ class RedTeamer:
         vulnerability_type: VulnerabilityType,
         vulnerabilities: List[BaseVulnerability],
         ignore_errors: bool,
+        reuse_simulated_test_cases: bool = False,
     ) -> RTTestCase:
         multi_turn = (
             simulated_test_case.turns is not None
@@ -509,6 +512,37 @@ class RedTeamer:
 
             if simulated_test_case.error is not None:
                 return red_teaming_test_case
+
+            # When reusing saved test cases, replay user turns through
+            # model_callback to replace stale assistant responses.
+            if reuse_simulated_test_cases:
+                sig = inspect.signature(model_callback)
+                fresh_turns = []
+                for turn in simulated_test_case.turns:
+                    if turn.role == "user":
+                        try:
+                            if "turns" in sig.parameters:
+                                model_response = model_callback(
+                                    turn.content, list(fresh_turns)
+                                )
+                            else:
+                                model_response = model_callback(turn.content)
+                        except Exception:
+                            if ignore_errors:
+                                red_teaming_test_case.error = (
+                                    "Error generating output from target LLM"
+                                )
+                                return red_teaming_test_case
+                            else:
+                                raise
+                        fresh_turns.append(turn)
+                        fresh_turns.append(
+                            RTTurn(
+                                role="assistant",
+                                content=model_response.content,
+                            )
+                        )
+                red_teaming_test_case.turns = fresh_turns
 
             try:
                 metric.measure(red_teaming_test_case)
@@ -571,6 +605,7 @@ class RedTeamer:
         vulnerability_type: VulnerabilityType,
         vulnerabilities: List[BaseVulnerability],
         ignore_errors: bool,
+        reuse_simulated_test_cases: bool = False,
     ) -> RTTestCase:
         multi_turn = (
             simulated_test_case.turns is not None
@@ -590,6 +625,39 @@ class RedTeamer:
 
             if red_teaming_test_case.error is not None:
                 return red_teaming_test_case
+
+            # When reusing saved test cases, replay user turns through
+            # model_callback to replace stale assistant responses.
+            if reuse_simulated_test_cases:
+                sig = inspect.signature(model_callback)
+                fresh_turns = []
+                for turn in simulated_test_case.turns:
+                    if turn.role == "user":
+                        try:
+                            if "turns" in sig.parameters:
+                                model_response = await model_callback(
+                                    turn.content, list(fresh_turns)
+                                )
+                            else:
+                                model_response = await model_callback(
+                                    turn.content
+                                )
+                        except Exception:
+                            if ignore_errors:
+                                red_teaming_test_case.error = (
+                                    "Error generating output from target LLM"
+                                )
+                                return red_teaming_test_case
+                            else:
+                                raise
+                        fresh_turns.append(turn)
+                        fresh_turns.append(
+                            RTTurn(
+                                role="assistant",
+                                content=model_response.content,
+                            )
+                        )
+                red_teaming_test_case.turns = fresh_turns
 
             try:
                 await metric.a_measure(red_teaming_test_case)
@@ -651,6 +719,7 @@ class RedTeamer:
         vulnerability_type: VulnerabilityType,
         simulated_test_cases: List[RTTestCase],
         ignore_errors: bool,
+        reuse_simulated_test_cases: bool = False,
     ) -> List[RTTestCase]:
         red_teaming_test_cases = []
 
@@ -663,6 +732,7 @@ class RedTeamer:
                     vulnerability=simulated_test_case.vulnerability,
                     vulnerability_type=vulnerability_type,
                     ignore_errors=ignore_errors,
+                    reuse_simulated_test_cases=reuse_simulated_test_cases,
                 )
             )
 
@@ -675,6 +745,7 @@ class RedTeamer:
         vulnerability_type: VulnerabilityType,
         simulated_test_cases: List[RTTestCase],
         ignore_errors: bool,
+        reuse_simulated_test_cases: bool = False,
     ) -> List[RTTestCase]:
         red_teaming_test_cases = await asyncio.gather(
             *[
@@ -685,6 +756,7 @@ class RedTeamer:
                     vulnerability=simulated_test_case.vulnerability,
                     vulnerability_type=vulnerability_type,
                     ignore_errors=ignore_errors,
+                    reuse_simulated_test_cases=reuse_simulated_test_cases,
                 )
                 for simulated_test_case in simulated_test_cases
             ]


### PR DESCRIPTION
## Summary

Fixes #199.

When `reuse_simulated_test_cases=True` is passed to `red_team()` / `a_red_team()`, multi-turn attacks (e.g. `LinearJailbreaking`, `CrescendoJailbreaking`) were skipping `model_callback` entirely. The multi-turn branch in `_attack` / `_a_attack` jumped straight to `metric.measure()` with the stale dummy assistant responses stored during the simulation phase — so the evaluation was measuring the simulator's placeholder outputs, not the actual target model's responses.

## Root Cause

The `reuse_simulated_test_cases` flag was never threaded into `_attack` / `_a_attack`. The single-turn path correctly called `model_callback` before evaluating; the multi-turn path did not.

## Changes

- Added `reuse_simulated_test_cases: bool = False` parameter to `_attack`, `_a_attack`, `_evaluate_vulnerability_type`, `_a_evaluate_vulnerability_type`
- When the flag is `True` and the test case is multi-turn: iterates the stored turns, calls `model_callback` for each `user` turn (passes conversation history as second arg if the callback signature accepts a `turns` parameter), and rebuilds a fresh turns list with the new assistant responses before passing to `metric.measure()`
- Threaded the flag through the full call chain in both sync and async paths

## Behaviour Before / After

| Scenario | Before | After |
|---|---|---|
| `reuse_simulated_test_cases=False` | ✅ correct | ✅ unchanged |
| `reuse_simulated_test_cases=True`, single-turn | ✅ correct | ✅ unchanged |
| `reuse_simulated_test_cases=True`, multi-turn | ❌ stale dummy responses evaluated | ✅ fresh responses from `model_callback` evaluated |

## Test Plan

- [ ] Run a multi-turn attack (e.g. `LinearJailbreaking`) with `reuse_simulated_test_cases=True` on a second call — verify `model_callback` is invoked for each user turn and scores reflect fresh responses
- [ ] Confirm single-turn and `reuse_simulated_test_cases=False` paths are unaffected
- [ ] Confirm async (`a_red_team`) and sync (`red_team`) paths both work correctly