### PR TITLE
Fix: append_target_turn accepts raw strings, causing AttributeError in multi-turn attacks

### DIFF
--- a/deepteam/attacks/multi_turn/utils.py
+++ b/deepteam/attacks/multi_turn/utils.py
@@ -7,11 +7,41 @@ from deepteam.test_case import RTTurn
 
 
 def append_target_turn(
-    turns: List[RTTurn], target_response: RTTurn, turn_level_attack: str = None
+    turns: List[RTTurn],
+    target_response,
+    turn_level_attack: str = None,
 ):
+    """
+    Append a model response to the turn history as an RTTurn.
+
+    Normalizes input so the turn history always contains RTTurn objects,
+    regardless of what model_callback returns. This guarantees that
+    downstream code iterating the history can safely access .role and
+    .content on every element.
+
+    Args:
+        turns: The conversation history to append to.
+        target_response: The model's response. Accepts:
+            - RTTurn: appended as-is.
+            - str: wrapped as RTTurn(role="assistant", content=target_response).
+            - other: coerced via str() and wrapped as an assistant RTTurn.
+        turn_level_attack: Optional name of the turn-level attack that
+            produced this response. Set as an attribute on the resulting
+            RTTurn for downstream tracking.
+    """
+    # Normalize to RTTurn so the history is always typed consistently.
+    if isinstance(target_response, RTTurn):
+        turn = target_response
+    elif isinstance(target_response, str):
+        turn = RTTurn(role="assistant", content=target_response)
+    else:
+        # Fallback for any other model-specific return types
+        turn = RTTurn(role="assistant", content=str(target_response))
+
     if turn_level_attack:
-        target_response.turn_level_attack = turn_level_attack
-    turns.append(target_response)
+        turn.turn_level_attack = turn_level_attack
+
+    turns.append(turn)
 
 
 def update_turn_history(

--- a/tests/test_core/test_attacks/test_append_target_turn.py
+++ b/tests/test_core/test_attacks/test_append_target_turn.py
@@ -1,0 +1,99 @@
+"""
+Regression tests for deepteam.attacks.multi_turn.utils.append_target_turn.
+
+These tests cover the type-safety fix that ensures the turn history
+always contains RTTurn objects, regardless of what model_callback returns.
+"""
+import pytest
+
+from deepteam.test_case import RTTurn
+from deepteam.attacks.multi_turn.utils import append_target_turn
+
+
+class TestAppendTargetTurn:
+    """Regression tests for the turn-history type-safety fix."""
+
+    def test_string_response_is_wrapped_in_rtturn(self):
+        """model_callback returns a str -- should be wrapped, not appended raw."""
+        turns = [RTTurn(role="user", content="hello")]
+        append_target_turn(turns, "hi there")
+
+        assert len(turns) == 2
+        assert isinstance(turns[-1], RTTurn)
+        assert turns[-1].role == "assistant"
+        assert turns[-1].content == "hi there"
+
+    def test_rtturn_response_is_appended_unchanged(self):
+        """Backwards compatibility: passing an RTTurn must still work."""
+        turns = [RTTurn(role="user", content="hello")]
+        response = RTTurn(role="assistant", content="hi there")
+        append_target_turn(turns, response)
+
+        assert len(turns) == 2
+        assert turns[-1] is response  # same object, not a copy
+        assert turns[-1].role == "assistant"
+        assert turns[-1].content == "hi there"
+
+    def test_non_string_non_rtturn_response_is_coerced(self):
+        """Fallback path: arbitrary objects get str()-coerced into content."""
+        turns = [RTTurn(role="user", content="hello")]
+        append_target_turn(turns, 42)
+
+        assert len(turns) == 2
+        assert isinstance(turns[-1], RTTurn)
+        assert turns[-1].role == "assistant"
+        assert turns[-1].content == "42"
+
+    def test_turn_level_attack_attribute_set_on_string_response(self):
+        """
+        Regression for the second latent AttributeError:
+        when target_response is a str AND turn_level_attack is provided,
+        the attribute assignment must run on the wrapped RTTurn, not the str.
+        """
+        turns = [RTTurn(role="user", content="hello")]
+        append_target_turn(
+            turns, "hi there", turn_level_attack="PromptInjection"
+        )
+
+        assert isinstance(turns[-1], RTTurn)
+        assert turns[-1].turn_level_attack == "PromptInjection"
+        assert turns[-1].content == "hi there"
+
+    def test_turn_level_attack_attribute_set_on_rtturn_response(self):
+        """Existing path: RTTurn input with attack name set."""
+        turns = [RTTurn(role="user", content="hello")]
+        response = RTTurn(role="assistant", content="hi there")
+        append_target_turn(
+            turns, response, turn_level_attack="LinearJailbreaking"
+        )
+
+        assert turns[-1].turn_level_attack == "LinearJailbreaking"
+
+    def test_no_turn_level_attack_does_not_set_attribute(self):
+        """When turn_level_attack is None, the attribute should not be set
+        (or should remain falsy / None)."""
+        turns = [RTTurn(role="user", content="hello")]
+        append_target_turn(turns, "hi there")
+
+        # Attribute should not be set when not provided
+        assert (
+            not hasattr(turns[-1], "turn_level_attack")
+            or turns[-1].turn_level_attack is None
+        )
+
+    def test_history_is_iterable_with_role_attribute_after_append(self):
+        """
+        Integration-style check: simulate the downstream pattern that
+        originally crashed. Iterating turns and reading .role must
+        succeed for every element, including those appended from raw strings.
+        """
+        turns = [RTTurn(role="user", content="user message")]
+        append_target_turn(turns, "assistant string response")
+        append_target_turn(
+            turns, RTTurn(role="user", content="follow-up")
+        )
+        append_target_turn(turns, "another assistant string")
+
+        # This is the loop that used to fail in JailBreakingTemplate
+        roles = [turn.role for turn in turns]
+        assert roles == ["user", "assistant", "user", "assistant"]


### PR DESCRIPTION
**Title**
Fix: append_target_turn accepts raw strings, causing AttributeError: 'str' object has no attribute 'role' in multi-turn attacks

**Summary**
This PR fixes a bug where LinearJailbreaking and other multi-turn attacks crash when append_target_turn() inserts raw strings into the turn history. The function's signature declares target_response: RTTurn, but every caller in the library passes the raw string returned by model_callback(...). Downstream code (e.g. JailBreakingTemplate.improvement_prompt) then iterates the history expecting .role and .content attributes and fails with:
AttributeError: 'str' object has no attribute 'role'
This PR aligns runtime behavior with the declared contract by normalizing the input inside append_target_turn, ensuring the turn history always contains RTTurn objects.

**Issue Description**
_Root Cause_
append_target_turn() is typed to receive an RTTurn but is universally called with a raw string:
# deepteam/attacks/multi_turn/utils.py
def append_target_turn(
    turns: List[RTTurn], target_response: RTTurn, turn_level_attack: str = None
):
    if turn_level_attack:
        target_response.turn_level_attack = turn_level_attack
    turns.append(target_response)

# deepteam/attacks/multi_turn/linear_jailbreaking/linear_jailbreaking.py
target_response = model_callback(current_attack, turns)
append_target_turn(turns, target_response)   # target_response is a str
Later, JailBreakingTemplate.improvement_prompt() iterates the history:
for turn in turn_history:
    if turn.role == "user":
        ...
This fails when turn is a string.

_Impact_
All multi-turn attacks (LinearJailbreaking, SequentialJailbreak, etc.) crash at the first appended assistant response.
A second latent AttributeError exists on the turn_level_attack branch: target_response.turn_level_attack = turn_level_attack runs before any type check, so it would also fail on a string. The original traceback didn't surface it only because the random turn_level_attacks branch didn't fire.
Users cannot run red-team evaluations unless they manually wrap model responses in RTTurn inside their model_callback.
The error is non-obvious — the traceback points at a template file, several layers away from the actual append site.

**Reproduction Steps**
Minimal reproducible example:
from deepteam.test_case import RTTurn
from deepteam.attacks.multi_turn.utils import append_target_turn
from deepteam.attacks.multi_turn.linear_jailbreaking.template import JailBreakingTemplate


turns = [RTTurn(role="user", content="test")]
response = "hello world"  # model_callback returns a str
append_target_turn(turns, response)


JailBreakingTemplate.improvement_prompt(turns, "feedback")
# AttributeError: 'str' object has no attribute 'role'
The same crash reproduces end-to-end by running any LinearJailbreaking attack with a model_callback that returns a string (which is the documented and idiomatic return type).

**Proposed Fix**
Normalize inside append_target_turn so the turn history is guaranteed to contain RTTurn objects, regardless of what model_callback returns. The wrapping happens before the turn_level_attack assignment, fixing both crashes in one change.

_Patch_
 def append_target_turn(
-    turns: List[RTTurn], target_response: RTTurn, turn_level_attack: str = None
+    turns: List[RTTurn],
+    target_response,                         # str | RTTurn | other
+    turn_level_attack: str = None,
 ):
-    if turn_level_attack:
-        target_response.turn_level_attack = turn_level_attack
-    turns.append(target_response)
+    # Normalize to RTTurn so the history is always typed consistently.
+    if isinstance(target_response, RTTurn):
+        turn = target_response
+    elif isinstance(target_response, str):
+        turn = RTTurn(role="assistant", content=target_response)
+    else:
+        # Fallback for any other model-specific return types
+        turn = RTTurn(role="assistant", content=str(target_response))
+
+    if turn_level_attack:
+        turn.turn_level_attack = turn_level_attack
+
+    turns.append(turn)
This guarantees type safety without requiring users to modify their model_callback.

_Alternative Considered_
Tightening the callers instead — wrapping the response into an RTTurn at every call site in linear_jailbreaking.py, sequential_jailbreak.py, etc. Rejected because (a) it touches more files, (b) it leaves the utility's type contract unenforced, and (c) it doesn't help third-party attacks that depend on this helper. Happy to switch to this approach if maintainers prefer it.

**Additional Improvements**
Added a unit test asserting append_target_turn() produces RTTurn objects for str, RTTurn, and arbitrary inputs.
Added a test covering the turn_level_attack branch with a string input (regression for the second latent crash).
Updated the docstring to clarify the accepted input types.

**Why This Fix Is Safe**
No changes to attack logic or judge/improvement prompts.
No changes to model behavior or output content.
Only enforces a data-structure invariant that downstream code already assumed.
Backwards compatible: callers that already pass an RTTurn get identical behavior.

**Checklist**
[x] Bug reproduced
[x] Fix implemented
[x] Tests added (including regression for the turn_level_attack branch)
[x] No breaking API changes
[x] Multi-turn attacks now run end-to-end without errors
