### PR TITLE
Add ISO/IEC 42001 framework

### DIFF
--- a/deepteam/frameworks/__init__.py
+++ b/deepteam/frameworks/__init__.py
@@ -1,6 +1,7 @@
 from .frameworks import AISafetyFramework
 from .aegis.aegis import Aegis
 from .nist.nist import NIST
+from .iso_42001.iso_42001 import ISO42001
 from .owasp.owasp import OWASPTop10
 from .mitre.mitre import MITRE
 from .beavertails.beavertails import BeaverTails
@@ -13,6 +14,7 @@ __all__ = [
     "OWASP_ASI_2026",
     "NIST",
     "Aegis",
+    "ISO42001",
     "BeaverTails",
     "MITRE",
     "EUAIAct",

--- a/deepteam/frameworks/iso_42001/__init__.py
+++ b/deepteam/frameworks/iso_42001/__init__.py
@@ -1,0 +1,6 @@
+from deepteam.frameworks.iso_42001.iso_42001 import ISO42001
+from deepteam.frameworks.iso_42001.risk_categories import (
+    ISO_42001_CATEGORIES,
+)
+
+__all__ = ["ISO42001", "ISO_42001_CATEGORIES"]

--- a/deepteam/frameworks/iso_42001/iso_42001.py
+++ b/deepteam/frameworks/iso_42001/iso_42001.py
@@ -1,0 +1,89 @@
+"""
+ISO/IEC 42001:2023 — AI Management Systems framework mapper.
+
+See ``risk_categories`` for the in-scope vs. out-of-scope rationale and
+the per-control vulnerability/attack mapping.
+"""
+
+from typing import List, Literal
+
+from deepteam.attacks import BaseAttack
+from deepteam.frameworks import AISafetyFramework
+from deepteam.frameworks.iso_42001.risk_categories import (
+    ISO_42001_CATEGORIES,
+)
+from deepteam.vulnerabilities import BaseVulnerability
+
+
+class ISO42001(AISafetyFramework):
+    name = "ISO/IEC 42001:2023 — AI Management Systems"
+    description = (
+        "Red-team evidence aligned to seven outcome-focused ISO/IEC "
+        "42001:2023 Annex A controls: fairness (A.6.2.4), robustness "
+        "(A.6.2.5), security (A.6.2.6), privacy (A.6.2.7), transparency "
+        "(A.6.2.8), safety and ethical use (A.9.2), and accountability "
+        "with human oversight (A.9.3)."
+    )
+
+    ALLOWED_TYPES = [
+        "A.6.2.4",
+        "A.6.2.5",
+        "A.6.2.6",
+        "A.6.2.7",
+        "A.6.2.8",
+        "A.9.2",
+        "A.9.3",
+    ]
+
+    def __init__(
+        self,
+        categories: List[
+            Literal[
+                "A.6.2.4",
+                "A.6.2.5",
+                "A.6.2.6",
+                "A.6.2.7",
+                "A.6.2.8",
+                "A.9.2",
+                "A.9.3",
+            ]
+        ] = None,
+    ):
+        if categories is None:
+            categories = list(self.ALLOWED_TYPES)
+
+        invalid = [c for c in categories if c not in self.ALLOWED_TYPES]
+        if invalid:
+            raise ValueError(
+                f"Unknown ISO/IEC 42001 control id(s): {invalid}. "
+                f"Allowed: {self.ALLOWED_TYPES}"
+            )
+
+        # Map the user-facing control id to the internal RiskCategory key.
+        control_to_key = {
+            "A.6.2.4": "a_6_2_4_fairness",
+            "A.6.2.5": "a_6_2_5_reliability_robustness",
+            "A.6.2.6": "a_6_2_6_security",
+            "A.6.2.7": "a_6_2_7_privacy",
+            "A.6.2.8": "a_6_2_8_transparency",
+            "A.9.2": "a_9_2_responsible_use",
+            "A.9.3": "a_9_3_human_oversight",
+        }
+        wanted_keys = {control_to_key[c] for c in categories}
+
+        self.categories = categories
+        self.risk_categories = [
+            rc for rc in ISO_42001_CATEGORIES if rc.name in wanted_keys
+        ]
+
+        vulnerabilities: List[BaseVulnerability] = []
+        attacks: List[BaseAttack] = []
+        for rc in self.risk_categories:
+            vulnerabilities.extend(rc.vulnerabilities)
+            attacks.extend(rc.attacks)
+
+        self.vulnerabilities = vulnerabilities
+        self.attacks = attacks
+
+    def get_name(self) -> str:
+        return self.name

--- a/deepteam/frameworks/iso_42001/risk_categories.py
+++ b/deepteam/frameworks/iso_42001/risk_categories.py
@@ -1,0 +1,247 @@
+"""
+ISO/IEC 42001:2023 Annex A risk categories — focused profile.
+
+Scoped to seven outcome themes that can be exercised via red-team:
+
+  * Fairness & Bias Prevention            -> A.6.2.4
+  * Robustness & Resilience               -> A.6.2.5
+  * Security & Vulnerability Management   -> A.6.2.6
+  * Privacy & Data Protection             -> A.6.2.7
+  * Transparency & Trustworthiness        -> A.6.2.8
+  * Safety & Ethical Use                  -> A.9.2
+  * Accountability & Human Oversight      -> A.9.3
+
+All other Annex A controls (data lineage A.7.2/A.7.4, external reporting
+A.8.3, intended use A.9.4, third-party AI A.10.2) and pure-governance
+controls (A.4.2, A.6.2.3, A.7.3, A.8.2, A.10.3/A.10.4) are intentionally
+omitted from this profile. They are out of scope for behavioral
+red-team evidence and require governance artifacts instead.
+
+Reference: ISO/IEC 42001:2023, Annex A.
+"""
+
+from deepteam.attacks.multi_turn import (
+    BadLikertJudge,
+    CrescendoJailbreaking,
+    LinearJailbreaking,
+    SequentialJailbreak,
+    TreeJailbreaking,
+)
+from deepteam.attacks.single_turn import (
+    AuthorityEscalation,
+    Base64,
+    ContextPoisoning,
+    EmotionalManipulation,
+    GoalRedirection,
+    Multilingual,
+    PromptInjection,
+    Roleplay,
+    SystemOverride,
+)
+from deepteam.frameworks.risk_category import RiskCategory
+from deepteam.vulnerabilities import (
+    BFLA,
+    BOLA,
+    PIILeakage,
+    RBAC,
+    SQLInjection,
+    SSRF,
+    Bias,
+    DebugAccess,
+    ExcessiveAgency,
+    Hallucination,
+    IllegalActivity,
+    Misinformation,
+    PromptLeakage,
+    Robustness,
+    ShellInjection,
+    Toxicity,
+)
+
+
+# -------------------------------------------------------- Fairness & Bias Prevention
+a_6_2_4_fairness = RiskCategory(
+    name="a_6_2_4_fairness",
+    _display_name="A.6.2.4 — Fairness & Bias Prevention",
+    description=(
+        "The AI system avoids unfair bias against protected groups. "
+        "Probes test for disparate treatment across race, gender, age, "
+        "religion, and political orientation under direct, multilingual, "
+        "and emotionally-charged framings."
+    ),
+    vulnerabilities=[
+        Bias(types=["race", "gender", "religion", "politics"]),
+        Toxicity(types=["insults", "profanity", "threats", "mockery"]),
+    ],
+    attacks=[
+        Roleplay(weight=2),
+        Multilingual(weight=1),
+        EmotionalManipulation(weight=1),
+        LinearJailbreaking(weight=1),
+    ],
+)
+
+
+# ---------------------------------------------------------- Robustness & Resilience
+a_6_2_5_reliability_robustness = RiskCategory(
+    name="a_6_2_5_reliability_robustness",
+    _display_name="A.6.2.5 — Robustness & Resilience",
+    description=(
+        "The AI system performs consistently under expected and "
+        "adversarial conditions. Probes stress output stability through "
+        "context poisoning, goal redirection, and progressive multi-turn "
+        "attacks."
+    ),
+    vulnerabilities=[
+        Robustness(types=["input_overreliance", "hijacking"]),
+        Hallucination(),
+        Misinformation(types=[
+            "factual_errors",
+            "unsupported_claims",
+            "expertize_misrepresentation",
+        ]),
+    ],
+    attacks=[
+        ContextPoisoning(weight=2),
+        GoalRedirection(weight=1),
+        SequentialJailbreak(weight=1),
+        CrescendoJailbreaking(weight=2),
+        TreeJailbreaking(weight=1),
+    ],
+)
+
+
+# ------------------------------------------- Security & Vulnerability Management
+a_6_2_6_security = RiskCategory(
+    name="a_6_2_6_security",
+    _display_name="A.6.2.6 — Security & Vulnerability Management",
+    description=(
+        "The AI system is protected against adversarial threats and "
+        "unauthorized actions. Covers prompt leakage, injection-style "
+        "attacks against tool-using agents, and access-control bypass."
+    ),
+    vulnerabilities=[
+        PromptLeakage(types=["secrets_and_credentials", "instructions"]),
+        ShellInjection(),
+        SQLInjection(),
+        SSRF(),
+        DebugAccess(),
+        RBAC(),
+        BFLA(),
+        BOLA(),
+    ],
+    attacks=[
+        PromptInjection(weight=2),
+        Base64(weight=1),
+        AuthorityEscalation(weight=1),
+        SystemOverride(weight=1),
+        LinearJailbreaking(weight=1),
+        TreeJailbreaking(weight=1),
+        BadLikertJudge(weight=1),
+    ],
+)
+
+
+# ----------------------------------------------------- Privacy & Data Protection
+a_6_2_7_privacy = RiskCategory(
+    name="a_6_2_7_privacy",
+    _display_name="A.6.2.7 — Privacy & Data Protection",
+    description=(
+        "Personal data is processed lawfully, minimally, and is not "
+        "leaked. Probes target direct, indirect, and cross-context PII "
+        "exposure as well as system-prompt extraction."
+    ),
+    vulnerabilities=[
+        PIILeakage(types=[
+            "direct_disclosure",
+            "session_leak",
+            "social_manipulation",
+        ]),
+        PromptLeakage(types=["secrets_and_credentials"]),
+    ],
+    attacks=[
+        Roleplay(weight=2),
+        EmotionalManipulation(weight=1),
+        Multilingual(weight=1),
+        CrescendoJailbreaking(weight=2),
+    ],
+)
+
+
+# ----------------------------------------------- Transparency & Trustworthiness
+a_6_2_8_transparency = RiskCategory(
+    name="a_6_2_8_transparency",
+    _display_name="A.6.2.8 — Transparency & Trustworthiness",
+    description=(
+        "System behavior is explainable to relevant stakeholders. "
+        "Behavioral evidence that the system does not fabricate "
+        "explanations or invent reasoning."
+    ),
+    vulnerabilities=[
+        Hallucination(),
+        Misinformation(types=["unsupported_claims"]),
+    ],
+    attacks=[
+        PromptInjection(weight=1),
+        ContextPoisoning(weight=1),
+    ],
+)
+
+
+# ----------------------------------------------------------- Safety & Ethical Use
+a_9_2_responsible_use = RiskCategory(
+    name="a_9_2_responsible_use",
+    _display_name="A.9.2 — Safety & Ethical Use",
+    description=(
+        "Operational processes prevent misuse and ensure responsible, "
+        "ethical use. Probes test compliance with usage boundaries "
+        "under social-engineering and escalating multi-turn pressure."
+    ),
+    vulnerabilities=[
+        ExcessiveAgency(types=["functionality", "permissions", "autonomy"]),
+        IllegalActivity(types=[
+            "weapons",
+            "cybercrime",
+            "non_violent_crimes",
+        ]),
+    ],
+    attacks=[
+        AuthorityEscalation(weight=2),
+        GoalRedirection(weight=1),
+        CrescendoJailbreaking(weight=2),
+        SequentialJailbreak(weight=1),
+    ],
+)
+
+
+# -------------------------------------------- Accountability & Human Oversight
+a_9_3_human_oversight = RiskCategory(
+    name="a_9_3_human_oversight",
+    _display_name="A.9.3 — Accountability & Human Oversight",
+    description=(
+        "Meaningful human oversight and accountability over AI "
+        "decisions. Probes attempt to remove, skip, or silently bypass "
+        "human-in-the-loop checkpoints."
+    ),
+    vulnerabilities=[
+        ExcessiveAgency(types=["autonomy", "permissions"]),
+    ],
+    attacks=[
+        AuthorityEscalation(weight=2),
+        GoalRedirection(weight=2),
+        SystemOverride(weight=1),
+        CrescendoJailbreaking(weight=1),
+        TreeJailbreaking(weight=1),
+    ],
+)
+
+
+ISO_42001_CATEGORIES = [
+    a_6_2_4_fairness,
+    a_6_2_5_reliability_robustness,
+    a_6_2_6_security,
+    a_6_2_7_privacy,
+    a_6_2_8_transparency,
+    a_9_2_responsible_use,
+    a_9_3_human_oversight,
+]

--- a/docs/content/docs/frameworks-introduction.mdx
+++ b/docs/content/docs/frameworks-introduction.mdx
@@ -18,6 +18,7 @@ Here are the list of frameworks available in `deepteam`:
 - [NIST AI RMF](#nist-ai-rmf)
 - [MITRE ATLAS](#mitre-atlas)
 - [EU AI Act](#eu-ai-act)
+- [ISO/IEC 42001](#iso-iec-42001)
 - [BeaverTails](#beavertails)
 - [Aegis](#aegis)
 
@@ -129,6 +130,27 @@ risk = red_team(
 ```
 
 [Learn more about EU AI Act](/docs/frameworks-eu-ai-act)
+
+### ISO/IEC 42001
+
+ISO/IEC 42001:2023 is the first international standard for AI Management Systems (AIMS).
+DeepTeam's ISO 42001 module operationalises the seven Annex A controls whose intent can be exercised behaviourally — so you can generate red-team evidence that supports your management-system documentation.
+
+- Tests fairness, robustness, security, privacy, transparency, safety/ethical use, and human oversight
+- Maps each control to concrete vulnerabilities and attack strategies
+- Ideal for organisations pursuing ISO/IEC 42001 certification alongside their AIMS lifecycle controls
+
+```python
+from deepteam.frameworks import ISO42001
+iso_42001 = ISO42001()
+
+risk = red_team(
+    model_callback=your_model_callback,
+    framework=iso_42001
+)
+```
+
+[Learn more about ISO/IEC 42001](/docs/frameworks-iso-42001)
 
 ### BeaverTails
 

--- a/docs/content/docs/frameworks-iso-42001.mdx
+++ b/docs/content/docs/frameworks-iso-42001.mdx
@@ -1,0 +1,384 @@
+---
+title: ISO/IEC 42001
+sidebar_label: ISO/IEC 42001
+---
+
+import { ASSETS } from "@site/src/assets";
+
+DeepTeam's **ISO/IEC 42001 module** operationalises the seven Annex A controls that can be stress-tested behaviourally — fairness, robustness, security, privacy, transparency, safety/ethical use, and human oversight — so you can red-team your AI system against the obligations of the world's first management-system standard for AI.
+
+## About ISO/IEC 42001:2023
+
+**ISO/IEC 42001:2023 — Information technology — Artificial intelligence — Management system** is the first international standard that specifies requirements for establishing, implementing, maintaining, and continually improving an **Artificial Intelligence Management System (AIMS)**. It is structured like ISO 9001 or ISO 27001: a clause-based main body (Clauses 4-10) plus an **Annex A** of reference controls grouped by AI-specific risk areas.
+
+The standard targets organisations that **provide, develop, or use** AI systems and pushes them to:
+
+| Pillar                          | What it expects                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Governance & accountability** | Clear ownership of AI risks, policies, and decisions across the lifecycle                        |
+| **AI-specific risk management** | Identification, treatment, and continual review of risks unique to AI systems                    |
+| **Lifecycle controls**          | Data, model, deployment, and post-deployment controls aligned with Annex A                       |
+| **Human oversight**             | Meaningful human review and intervention for impactful decisions                                 |
+| **Transparency & disclosure**   | Documented system behaviour, intended use, and limitations communicated to stakeholders          |
+
+### What DeepTeam's ISO 42001 framework covers
+
+DeepTeam focuses on the Annex A controls whose intent can be **observed in the model's behaviour** under adversarial conditions:
+
+- **A.6.2.4** — Fairness & Bias Prevention
+- **A.6.2.5** — Robustness & Resilience
+- **A.6.2.6** — Security & Vulnerability Management
+- **A.6.2.7** — Privacy & Data Protection
+- **A.6.2.8** — Transparency & Trustworthiness
+- **A.9.2** — Safety & Ethical Use
+- **A.9.3** — Accountability & Human Oversight
+
+For each control, DeepTeam provides vulnerabilities and attack strategies that probe whether the system's behaviour is consistent with the control's intent.
+
+### What it does not cover
+
+Several Annex A controls are **governance, documentation, or process** obligations rather than behavioural ones. DeepTeam does not, and cannot, replace these. The framework deliberately omits:
+
+- **A.7.2 / A.7.4** — Data lineage, data quality, and data provenance recordkeeping
+- **A.8.3** — External reporting of AI system behaviour and incidents
+- **A.9.4** — Intended use, intended users, and out-of-scope use documentation
+- **A.10.2** — Allocation of responsibilities for third-party AI components and suppliers
+- **A.4.2 / A.6.2.3 / A.7.3 / A.8.2 / A.10.3 / A.10.4** — Purely governance-focused controls (AI policy, AI roles, risk assessment processes, customer-facing impact assessments, supplier audits)
+
+Use DeepTeam to generate **behavioural evidence** on how your AI system reacts to adversarial pressure, and combine it with your management system documentation, lifecycle records, and supplier controls to satisfy ISO/IEC 42001 in full.
+
+:::tip
+You can also run this assessment in the Confident AI platform without any code.
+
+<VideoDisplayer
+  src={ASSETS.redTeamingOwaspTop10LlmPlatformVideo}
+  confidentUrl="/docs/red-teaming/no-code-assessments/quickstart"
+  label="Learn how to run framework assessments on Confident AI"
+/>
+:::
+
+## Overview
+
+In DeepTeam, the ISO 42001 framework maps each in-scope Annex A control to concrete red-teaming vulnerabilities and attack strategies.
+
+| Control     | Theme                                  | Description                                                                              |
+| ----------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **A.6.2.4** | Fairness & Bias Prevention             | Avoids unfair bias across race, gender, age, religion, and political orientation         |
+| **A.6.2.5** | Robustness & Resilience                | Performs consistently under expected and adversarial conditions                          |
+| **A.6.2.6** | Security & Vulnerability Management    | Resists adversarial threats, prompt leakage, injection, and access-control bypass        |
+| **A.6.2.7** | Privacy & Data Protection              | Processes personal data lawfully and does not leak PII or system prompts                 |
+| **A.6.2.8** | Transparency & Trustworthiness         | Explainable behaviour without fabricated reasoning or unsupported claims                 |
+| **A.9.2**   | Safety & Ethical Use                   | Operates within usage boundaries and refuses misuse, harmful, or illegal requests        |
+| **A.9.3**   | Accountability & Human Oversight       | Preserves human-in-the-loop checkpoints; resists silent autonomy escalation              |
+
+## Using the ISO 42001 Framework in DeepTeam
+
+You can run a full ISO 42001 red team assessment, or limit it to specific controls, using:
+
+```python
+from deepteam import red_team
+from deepteam.frameworks import ISO42001
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.6", "A.6.2.7"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+risk_assessment = red_team(
+    model_callback=your_model_callback,
+    vulnerabilities=vulnerabilities,
+    attacks=attacks,
+)
+```
+
+The `ISO42001` framework accepts **ONE** optional parameter:
+
+- [Optional] `categories`: A list of Annex A control identifiers. If omitted, all **7** in-scope controls are included:
+    - `A.6.2.4`: Disparate treatment across protected groups under direct, multilingual, and emotionally-charged framings.
+    - `A.6.2.5`: Output stability under context poisoning, goal redirection, and progressive multi-turn pressure.
+    - `A.6.2.6`: Prompt leakage, prompt/code injection, and access-control bypass against tool-using agents.
+    - `A.6.2.7`: Direct, indirect, and cross-context PII exposure plus system-prompt and credential extraction.
+    - `A.6.2.8`: Fabricated explanations and unsupported reasoning under injected or poisoned context.
+    - `A.9.2`: Compliance with usage boundaries under social-engineering and escalating multi-turn pressure.
+    - `A.9.3`: Removal, skipping, or silent bypass of human-in-the-loop checkpoints.
+
+## Annex A — In-Scope Controls
+
+### Fairness & Bias Prevention
+
+**(ISO/IEC 42001 — A.6.2.4)**
+
+**Goal:** Ensure the AI system avoids unfair bias against protected groups and does not produce toxic outputs targeting people on the basis of identity.
+
+DeepTeam probes whether your system can be steered into disparate or toxic treatment across race, gender, religion, and political orientation under direct, multilingual, and emotionally-charged framings.
+
+**Example vulnerabilities**
+
+- `Bias` — _race, gender, religion, politics_
+- `Toxicity` — _insults, profanity, threats, mockery_
+
+**Example attacks**
+
+- `Roleplay`, `Multilingual`, `EmotionalManipulation`, `LinearJailbreaking`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.4"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Robustness & Resilience
+
+**(ISO/IEC 42001 — A.6.2.5)**
+
+**Goal:** Ensure the AI system performs consistently and predictably under both expected and adversarial conditions, without hallucinating, over-relying on inputs, or being hijacked.
+
+**Example vulnerabilities**
+
+- `Robustness` — _input_overreliance, hijacking_
+- `Hallucination`
+- `Misinformation` — _factual_errors, unsupported_claims, expertize_misrepresentation_
+
+**Example attacks**
+
+- `ContextPoisoning`, `GoalRedirection`
+- `SequentialJailbreak`, `CrescendoJailbreaking`, `TreeJailbreaking`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.5"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Security & Vulnerability Management
+
+**(ISO/IEC 42001 — A.6.2.6)**
+
+**Goal:** Ensure the AI system is protected against adversarial threats and unauthorised actions — including prompt leakage, injection attacks against tool-using agents, and access-control bypass.
+
+**Example vulnerabilities**
+
+- `PromptLeakage` — _secrets_and_credentials, instructions_
+- `ShellInjection`, `SQLInjection`, `SSRF`
+- `DebugAccess`
+- `RBAC`, `BFLA`, `BOLA`
+
+**Example attacks**
+
+- `PromptInjection`, `Base64`
+- `AuthorityEscalation`, `SystemOverride`
+- `LinearJailbreaking`, `TreeJailbreaking`, `BadLikertJudge`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.6"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Privacy & Data Protection
+
+**(ISO/IEC 42001 — A.6.2.7)**
+
+**Goal:** Ensure personal data is processed lawfully and minimally and is not leaked — including direct, indirect, and cross-context PII exposure as well as system-prompt and credential extraction.
+
+**Example vulnerabilities**
+
+- `PIILeakage` — _direct_disclosure, session_leak, social_manipulation_
+- `PromptLeakage` — _secrets_and_credentials_
+
+**Example attacks**
+
+- `Roleplay`, `EmotionalManipulation`, `Multilingual`, `CrescendoJailbreaking`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.7"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Transparency & Trustworthiness
+
+**(ISO/IEC 42001 — A.6.2.8)**
+
+**Goal:** Ensure system behaviour is explainable to relevant stakeholders — and that the system does not fabricate explanations, invent reasoning, or make unsupported claims under injected or poisoned context.
+
+**Example vulnerabilities**
+
+- `Hallucination`
+- `Misinformation` — _unsupported_claims_
+
+**Example attacks**
+
+- `PromptInjection`, `ContextPoisoning`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.6.2.8"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Safety & Ethical Use
+
+**(ISO/IEC 42001 — A.9.2)**
+
+**Goal:** Ensure operational processes prevent misuse and enforce responsible, ethical use — including refusing harmful, illegal, or out-of-scope requests under social-engineering and escalating multi-turn pressure.
+
+**Example vulnerabilities**
+
+- `ExcessiveAgency` — _functionality, permissions, autonomy_
+- `IllegalActivity` — _weapons, cybercrime, non_violent_crimes_
+
+**Example attacks**
+
+- `AuthorityEscalation`, `GoalRedirection`
+- `CrescendoJailbreaking`, `SequentialJailbreak`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.9.2"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+### Accountability & Human Oversight
+
+**(ISO/IEC 42001 — A.9.3)**
+
+**Goal:** Ensure meaningful human oversight and accountability over AI-mediated decisions — and that the system cannot be coerced into removing, skipping, or silently bypassing human-in-the-loop checkpoints.
+
+**Example vulnerabilities**
+
+- `ExcessiveAgency` — _autonomy, permissions_
+
+**Example attacks**
+
+- `AuthorityEscalation`, `GoalRedirection`
+- `SystemOverride`, `CrescendoJailbreaking`, `TreeJailbreaking`
+
+```python
+from deepteam.frameworks import ISO42001
+from deepteam import red_team
+from somewhere import your_model_callback
+
+iso_42001 = ISO42001(categories=["A.9.3"])
+attacks = iso_42001.attacks
+vulnerabilities = iso_42001.vulnerabilities
+
+red_team(
+    model_callback=your_model_callback,
+    attacks=attacks,
+    vulnerabilities=vulnerabilities,
+)
+```
+
+:::info Run ISO 42001 Assessments on Confident AI
+[Confident AI](https://www.confident-ai.com) lets you configure the ISO 42001 framework, schedule recurring risk assessments, manage vulnerabilities in one place, and share downloadable PDF reports with your auditors for AIMS alignment.
+:::
+
+## Management-system obligations beyond adversarial testing
+
+DeepTeam exercises the **behavioural** side of ISO/IEC 42001 — but the standard is, fundamentally, a **management system** standard. Clearing a red-team run does not, on its own, deliver an AIMS.
+
+:::warning
+**Adversarial testing alone does not equal ISO 42001 conformity.** Behavioural probes surface technical weaknesses you can fix; certification requires the management-system layers below.
+:::
+
+### AI policy and roles (Clauses 5, 6 / Annex A.4-A.5)
+
+- A documented **AI policy** approved by top management and reviewed periodically.
+- Clear **AI roles and responsibilities** across providers, deployers, and users — covering who can approve a model, who owns risk, and who signs off changes.
+- An **AI risk assessment and treatment process** linked to the broader organisational risk framework.
+
+### Lifecycle controls (Annex A.6-A.7)
+
+- **AI system impact assessment** before deployment, refreshed when context or use changes materially.
+- **Data lineage, quality, and provenance** records (A.7.2 / A.7.4) — what was used to train, evaluate, and fine-tune the system, and how that data was sourced.
+- **Validation and verification** procedures appropriate to the system's risk class.
+
+### Transparency and intended use (Annex A.8-A.9)
+
+- **External reporting** (A.8.3) of behaviour, limitations, and incidents — including disclosures to users that they are interacting with an AI system.
+- **Intended use** (A.9.4), intended users, and explicitly out-of-scope use documented and communicated.
+
+### Third-party AI components (Annex A.10)
+
+- **Allocation of responsibilities** (A.10.2) with suppliers and sub-processors of AI components, including evaluation and monitoring obligations.
+- Contractual and audit controls on third-party models and datasets.
+
+### Continual improvement (Clauses 9-10)
+
+- **Internal audits**, **management reviews**, and **corrective actions** that feed back into the policy, the risk register, and the controls themselves.
+- **Post-deployment monitoring** that includes adversarial-evaluation runs like the ones DeepTeam supports — but also operational metrics, user feedback, and incident data.
+
+## Best Practices
+
+1. **Pair behavioural evidence with management-system artefacts.** A DeepTeam report demonstrates control intent at the behavioural layer; combine it with your AI policy, risk register, and lifecycle records.
+2. **Re-run on material change.** Treat new data sources, new tools, new deployment contexts, or significant prompt changes as triggers for re-assessment under [A.9.2](#safety--ethical-use) and [A.9.3](#accountability--human-oversight).
+3. **Cover the full in-scope set.** ISO/IEC 42001 expects you to consider all relevant Annex A controls. Run the seven in-scope controls together rather than cherry-picking the comfortable ones.
+4. **Combine with NIST AI RMF and EU AI Act runs.** NIST RMF gives you measurable governance functions, EU AI Act gives you regulatory scope for EU markets, ISO 42001 gives you an audit-ready management system — they're complementary.
+5. **Feed findings into corrective action.** A failed probe is evidence for an Annex A non-conformity — close the loop through your management-review cycle, not in an isolated bug tracker.
+
+## Learn More
+
+- [ISO/IEC 42001:2023 — Official page](https://www.iso.org/standard/81230.html)
+- [NIST AI RMF (complementary governance framework)](https://www.nist.gov/itl/ai-risk-management-framework)
+- [EU AI Act (complementary regulatory framework)](/docs/frameworks-eu-ai-act)

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -31,6 +31,7 @@
     "frameworks-nist-ai-rmf",
     "frameworks-mitre-atlas",
     "frameworks-eu-ai-act",
+    "frameworks-iso-42001",
     "frameworks-beavertails",
     "frameworks-aegis",
 

--- a/tests/test_frameworks/test_iso_42001.py
+++ b/tests/test_frameworks/test_iso_42001.py
@@ -1,0 +1,199 @@
+import pytest
+from deepteam.frameworks import ISO42001
+from deepteam.red_teamer.risk_assessment import RiskAssessment
+from deepteam.vulnerabilities import BaseVulnerability
+from deepteam.attacks import BaseAttack
+from deepteam.frameworks.iso_42001.risk_categories import ISO_42001_CATEGORIES
+from deepteam.frameworks.risk_category import RiskCategory
+from deepteam import red_team
+
+
+ISO_42001_DEFAULT_CATEGORIES = {
+    "A.6.2.4",
+    "A.6.2.5",
+    "A.6.2.6",
+    "A.6.2.7",
+    "A.6.2.8",
+    "A.9.2",
+    "A.9.3",
+}
+
+
+class TestISO42001:
+
+    def test_iso_42001_init(self):
+        """Test that ISO 42001 framework can be instantiated."""
+        framework = ISO42001()
+        assert framework is not None
+
+    def test_iso_42001_name(self):
+        """Test that ISO 42001 framework has correct name."""
+        framework = ISO42001()
+        assert (
+            framework.name
+            == framework.get_name()
+            == "ISO/IEC 42001:2023 — AI Management Systems"
+        )
+
+    def test_iso_42001_description(self):
+        """Test that ISO 42001 framework has a non-empty description."""
+        framework = ISO42001()
+        assert isinstance(framework.description, str)
+        assert "ISO/IEC 42001:2023" in framework.description
+
+    def test_iso_42001_default_categories(self):
+        """Test that all default categories are included."""
+        framework = ISO42001()
+        assert set(framework.categories) == ISO_42001_DEFAULT_CATEGORIES
+
+    def test_iso_42001_partial_categories(self):
+        """Test that framework can be created with limited categories."""
+        framework = ISO42001(categories=["A.6.2.4", "A.6.2.5"])
+        assert set(framework.categories) == {"A.6.2.4", "A.6.2.5"}
+        assert len(framework.risk_categories) == 2
+
+    def test_iso_42001_invalid_category_raises(self):
+        """Test that passing an unknown control id raises ValueError."""
+        with pytest.raises(ValueError):
+            ISO42001(categories=["A.99.9"])
+
+    def test_iso_42001_vulnerabilities_exist(self):
+        """Test that vulnerabilities are defined and populated."""
+        for risk_category in ISO_42001_CATEGORIES:
+            assert hasattr(risk_category, "vulnerabilities")
+            assert risk_category.vulnerabilities is not None
+            assert len(risk_category.vulnerabilities) > 0
+
+    def test_iso_42001_vulnerabilities_are_instances(self):
+        """Test that all vulnerabilities are instances of BaseVulnerability."""
+        for risk_category in ISO_42001_CATEGORIES:
+            for vuln in risk_category.vulnerabilities:
+                assert isinstance(vuln, BaseVulnerability)
+
+    def test_iso_42001_attacks_exist(self):
+        """Test that attacks are defined and populated."""
+        for risk_category in ISO_42001_CATEGORIES:
+            assert hasattr(risk_category, "attacks")
+            assert risk_category.attacks is not None
+            assert len(risk_category.attacks) > 0
+
+    def test_iso_42001_attacks_are_instances(self):
+        """Test that all attacks are instances of BaseAttack."""
+        for risk_category in ISO_42001_CATEGORIES:
+            for attack in risk_category.attacks:
+                assert isinstance(attack, BaseAttack)
+
+    def test_iso_42001_attack_weights_valid(self):
+        """Test that all attacks have a valid weight in the [1, 3] range."""
+        for risk_category in ISO_42001_CATEGORIES:
+            for attack in risk_category.attacks:
+                assert hasattr(attack, "weight")
+                assert isinstance(attack.weight, int)
+                assert 1 <= attack.weight <= 3
+
+    def test_iso_42001_category_vulnerability_mapping(self):
+        """Test that all categories map to vulnerabilities properly."""
+        categories = ISO_42001_CATEGORIES
+        assert (
+            set([category.name for category in categories])
+            == {
+                "a_6_2_4_fairness",
+                "a_6_2_5_reliability_robustness",
+                "a_6_2_6_security",
+                "a_6_2_7_privacy",
+                "a_6_2_8_transparency",
+                "a_9_2_responsible_use",
+                "a_9_3_human_oversight",
+            }
+        )
+        for risk_category in categories:
+            assert isinstance(risk_category, RiskCategory)
+            assert all(
+                isinstance(v, BaseVulnerability)
+                for v in risk_category.vulnerabilities
+            )
+
+    def test_iso_42001_category_attack_mapping(self):
+        """Test that all categories map to attacks properly."""
+        categories = ISO_42001_CATEGORIES
+        for risk_category in categories:
+            assert isinstance(risk_category, RiskCategory)
+            assert all(isinstance(a, BaseAttack) for a in risk_category.attacks)
+
+    def test_iso_42001_vulnerability_names_present(self):
+        """Test that key ISO 42001 vulnerabilities are present across the framework."""
+        vuln_names = []
+        for risk_category in ISO_42001_CATEGORIES:
+            vuln_names.extend(
+                [v.__class__.__name__ for v in risk_category.vulnerabilities]
+            )
+        expected_vulns = [
+            "Bias",
+            "Toxicity",
+            "Robustness",
+            "Hallucination",
+            "Misinformation",
+            "PIILeakage",
+            "PromptLeakage",
+            "ShellInjection",
+            "SQLInjection",
+            "SSRF",
+            "DebugAccess",
+            "RBAC",
+            "BFLA",
+            "BOLA",
+            "ExcessiveAgency",
+            "IllegalActivity",
+        ]
+        for name in expected_vulns:
+            assert name in vuln_names, f"Expected vulnerability {name} not found"
+
+    def test_iso_42001_attack_names_present(self):
+        """Test that key ISO 42001 attacks are present across the framework."""
+        attack_names = []
+        for risk_category in ISO_42001_CATEGORIES:
+            attack_names.extend(
+                [a.__class__.__name__ for a in risk_category.attacks]
+            )
+        expected_attacks = [
+            "Roleplay",
+            "Multilingual",
+            "EmotionalManipulation",
+            "LinearJailbreaking",
+            "ContextPoisoning",
+            "GoalRedirection",
+            "SequentialJailbreak",
+            "CrescendoJailbreaking",
+            "TreeJailbreaking",
+            "PromptInjection",
+            "Base64",
+            "AuthorityEscalation",
+            "SystemOverride",
+            "BadLikertJudge",
+        ]
+        for name in expected_attacks:
+            assert name in attack_names, f"Expected attack {name} not found"
+
+    def test_iso_42001_framework_with_red_team(self):
+        import random
+
+        """Test that ISO 42001 framework integrates correctly with red_team function."""
+
+        # Simple mock model for testing
+        def mock_model_callback(prompt: str, turns=None) -> str:
+            return (
+                "I'm a safe AI model. I cannot comply with unsafe instructions."
+            )
+
+        categories = ["A.6.2.4", "A.6.2.5", "A.6.2.6"]
+        random_category = random.choice(categories)
+
+        risk_assessment = red_team(
+            model_callback=mock_model_callback,
+            framework=ISO42001(categories=[random_category]),
+            async_mode=False,
+            ignore_errors=False,
+        )
+
+        assert isinstance(risk_assessment, RiskAssessment)
+        assert risk_assessment is not None


### PR DESCRIPTION
Adds an ISO/IEC 42001:2023 - AI Management Systems framework, mirroring the existing EUAIAct and NIST framework structure. Scoped to the seven Annex A controls that can be exercised behaviourally:

  * A.6.2.4 - Fairness & Bias Prevention
  * A.6.2.5 - Robustness & Resilience
  * A.6.2.6 - Security & Vulnerability Management
  * A.6.2.7 - Privacy & Data Protection
  * A.6.2.8 - Transparency & Trustworthiness
  * A.9.2   - Safety & Ethical Use
  * A.9.3   - Accountability & Human Oversight

Governance-only controls (A.7.2/A.7.4 data lineage, A.8.3 reporting, A.9.4 intended use, A.10.2 third-party AI) are intentionally out of scope - they require documentation evidence rather than red-team probes, and the docs page calls this out.

Includes 16 unit tests, a docs page at parity with frameworks-eu-ai-act.mdx, and a landing-page entry in frameworks-introduction.mdx.