### PR TITLE
fix: remove unused nntplib import that breaks Python 3.13 support

### DIFF
--- a/deepteam/test_case/test_case.py
+++ b/deepteam/test_case/test_case.py
@@ -1,4 +1,3 @@
-from nntplib import NNTPDataError
 from typing import List, Optional
 from enum import Enum
 from deepeval.test_case import LLMTestCase, Turn, ToolCall


### PR DESCRIPTION
## What

Removes a single dead import: `from nntplib import NNTPDataError` in `deepteam/test_case/test_case.py`.

## Why

`nntplib` was removed from the Python standard library in 3.13 ([PEP 594](https://peps.python.org/pep-0594/)). `pyproject.toml` declares `python = ">=3.9,<3.14"`, so 3.13 is in the supported range, but the import currently makes the entire package fail at collection time on 3.13:
ModuleNotFoundError: No module named 'nntplib'

`NNTPDataError` is imported on line 1 of `test_case.py` and **referenced nowhere in the codebase** — confirmed with `grep -rn "NNTPDataError" --include="*.py" .`. It's a dead import, almost certainly an IDE-autocomplete accident that slipped through review.

## How verified

- Removed the line locally on Python 3.13.2
- Uninstalled the `standard-nntplib` backport shim to ensure no fallback
- `from deepteam.test_case import RTTestCase` now imports cleanly
- `pytest tests/test_core/test_vulnerabilities/test_shell_injection.py -v` collects and runs identically to baseline (6 pass, 4 fail on `OPENAI_API_KEY`-dependent paths as before)

## Scope

One line removed, zero lines added. No behavior change, no API change, no test change required.