### PR TITLE
fix(risk_assessment): errored total always reported as 0 (variable shadowing)

### DIFF
--- a/deepteam/red_teamer/risk_assessment.py
+++ b/deepteam/red_teamer/risk_assessment.py
@@ -213,9 +213,9 @@ def construct_risk_assessment_overview(
         passing = sum(
             1 for tc in test_cases if tc.score is not None and tc.score > 0
         )
-        errored = sum(1 for tc in test_cases if tc.error is not None)
-        failing = len(test_cases) - passing - errored
-        valid_cases = len(test_cases) - errored
+        type_errored = sum(1 for tc in test_cases if tc.error is not None)
+        failing = len(test_cases) - passing - type_errored
+        valid_cases = len(test_cases) - type_errored
         pass_rate = (passing / valid_cases) if valid_cases > 0 else 0.0
 
         vulnerability_type_results.append(
@@ -225,7 +225,7 @@ def construct_risk_assessment_overview(
                 pass_rate=pass_rate,
                 passing=passing,
                 failing=failing,
-                errored=errored,
+                errored=type_errored,
             )
         )
 
@@ -235,9 +235,9 @@ def construct_risk_assessment_overview(
             passing = sum(
                 1 for tc in test_cases if tc.score is not None and tc.score > 0
             )
-            errored = sum(1 for tc in test_cases if tc.error is not None)
-            failing = len(test_cases) - passing - errored
-            valid_cases = len(test_cases) - errored
+            method_errored = sum(1 for tc in test_cases if tc.error is not None)
+            failing = len(test_cases) - passing - method_errored
+            valid_cases = len(test_cases) - method_errored
             pass_rate = (passing / valid_cases) if valid_cases > 0 else 0.0
 
             attack_method_results.append(
@@ -246,7 +246,7 @@ def construct_risk_assessment_overview(
                     pass_rate=pass_rate,
                     passing=passing,
                     failing=failing,
-                    errored=errored,
+                    errored=method_errored,
                 )
             )
 

--- a/tests/test_core/test_risk_assessment.py
+++ b/tests/test_core/test_risk_assessment.py
@@ -1,0 +1,37 @@
+from deepteam.test_case import RTTestCase
+from deepteam.vulnerabilities.bias import BiasType
+from deepteam.red_teamer.risk_assessment import (
+    construct_risk_assessment_overview,
+)
+
+
+def _case(score=None, error=None, attack_method=None):
+    return RTTestCase(
+        vulnerability="Bias",
+        vulnerability_type=BiasType.RACE,
+        input="input",
+        actual_output=None if error else "output",
+        score=score,
+        error=error,
+        attack_method=attack_method,
+    )
+
+
+def test_overview_errored_count_is_not_clobbered():
+    """The top-level ``errored`` total (rendered to the user as the
+    '(N errored)' header) must reflect every errored test case, even when
+    some cases succeed. Regression for a variable-shadowing bug where the
+    per-group loop reused the ``errored`` accumulator name and overwrote it
+    with 0."""
+    test_cases = [
+        _case(score=1.0, attack_method="Base64"),  # passing
+        _case(score=0.0, attack_method="Base64"),  # failing
+        _case(error="model timeout", attack_method="Base64"),  # errored
+        _case(error="rate limited", attack_method="Base64"),  # errored
+    ]
+
+    overview = construct_risk_assessment_overview(
+        red_teaming_test_cases=test_cases, run_duration=1.0
+    )
+
+    assert overview.errored == 2


### PR DESCRIPTION
### problem
`construct_risk_assessment_overview` reports `0` errored test cases even when cases errored. the top-level `errored` accumulator (`errored += 1` in the outer loop) is later shadowed by per-group locals:
```python
errored = sum(1 for tc in test_cases if tc.error is not None)
```
inside the per-vulnerability-type and per-attack-method loops. errored cases are excluded from those groups by an earlier `continue`, so that sum is always 0, and after the loops `errored` holds `0` and is passed to `RedTeamingOverview(errored=errored)`. the console header (`red_teamer.py`: `🔍 DeepTeam Risk Assessment ({overview.errored} errored)`) then always shows `0`, masking failed evaluations.

### fix
rename the loop-locals (`type_errored` / `method_errored`) so the running total survives to the return. no other field changes (the per-group counts are identical).

### test
added `tests/test_core/test_risk_assessment.py::test_overview_errored_count_is_not_clobbered` (pure python, no keys): 4 cases (1 pass, 1 fail, 2 errored) -> `overview.errored == 2`. fails on main (gets 0), passes with the fix. black clean.

found by reading the code.
