### PR TITLE
docs: bring outbound UTM tagging up to the deepeval scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DeepTeam simulates attacks — jailbreaking, prompt injection, multi-turn exploi
 DeepTeam runs **locally on your machine** and is built on [DeepEval](https://github.com/confident-ai/deepeval), the open-source LLM evaluation framework.
 
 > [!IMPORTANT]
-> Need a place for your red teaming results to live? Sign up to the [Confident AI](https://app.confident-ai.com?utm_source=GitHub) platform to manage risk assessments, monitor vulnerabilities in production, and share reports with your team.
+> Need a place for your red teaming results to live? Sign up to the [Confident AI](https://app.confident-ai.com?utm_source=deepteam&utm_medium=github&utm_content=results_callout) platform to manage risk assessments, monitor vulnerabilities in production, and share reports with your team.
 
 <p align="center">
     <img src="https://github.com/confident-ai/deepteam/blob/main/assets/confident-demo.gif" alt="Confident AI + DeepTeam" width="100%">
@@ -288,7 +288,7 @@ print(output_result.breached)  # True
 
 # DeepTeam with Confident AI
 
-[Confident AI](https://app.confident-ai.com?utm_source=GitHub) is the all-in-one platform that integrates natively with DeepTeam and [DeepEval](https://github.com/confident-ai/deepeval).
+[Confident AI](https://app.confident-ai.com?utm_source=deepteam&utm_medium=github&utm_content=platform_section) is the all-in-one platform that integrates natively with DeepTeam and [DeepEval](https://github.com/confident-ai/deepeval).
 
 - **Manage risk assessments** — view, compare, and track red teaming results across iterations
 - **Monitor in production** — detect and alert on vulnerabilities hitting your live LLM system

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # DeepEval
 
-> DeepEval is an open-source LLM evaluation framework designed to unit-test LLM powered applications such as agents, chatbots, and RAG. DeepEval incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevancy, fluency, etc., which uses LLMs and various other NLP models that runs locally on your machine for evaluation. DeepEval integrates natively with [Confident AI](https://www.confident-ai.com), a separate AI quality platform with observability, evals, and monitoring that adds team-wide collaboration on top of DeepEval evals.
+> DeepEval is an open-source LLM evaluation framework designed to unit-test LLM powered applications such as agents, chatbots, and RAG. DeepEval incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevancy, fluency, etc., which uses LLMs and various other NLP models that runs locally on your machine for evaluation. DeepEval integrates natively with [Confident AI](https://www.confident-ai.com?utm_source=deepteam&utm_medium=llms_txt&utm_content=intro_mention), a separate AI quality platform with observability, evals, and monitoring that adds team-wide collaboration on top of DeepEval evals.
 
 - [DeepEval LLM Evaluation](https://deepeval.com/): Open-source framework for evaluating large language models effectively.
 - [DeepEval Framework Quickstart](https://deepeval.com/docs/getting-started): DeepEval is an open-source framework for evaluating LLM applications.
@@ -61,7 +61,7 @@
 - [Generate Synthetic Goldens](https://deepeval.com/docs/synthesizer-generate-from-goldens): Generate synthetic Goldens from existing Goldens easily.
 - [Improving QA Agent](https://deepeval.com/tutorials/qa-agent-improving-hyperparameters): Learn to enhance QA agent performance through hyperparameter tuning.
 - [Red Teaming Bias](https://www.trydeepteam.com/docs/red-teaming-vulnerabilities-bias): Test LLMs for bias in responses across various categories.
-- [Confident AI Documentation](https://www.confident-ai.com/docs/): AI quality platform with observability, evals, and monitoring — DeepEval integrates with it natively.
+- [Confident AI Documentation](https://www.confident-ai.com/docs/?utm_source=deepteam&utm_medium=llms_txt&utm_content=resources_docs_link): AI quality platform with observability, evals, and monitoring — DeepEval integrates with it natively.
 - [BIG-Bench Hard Evaluation](https://deepeval.com/docs/benchmarks-big-bench-hard): Evaluate language models with challenging BIG-Bench Hard tasks.
 - [LLM Tracing Guide](https://deepeval.com/docs/evaluation-llm-tracing): Learn to evaluate LLM interactions with tracing metrics.
 - [Document Summarization Datasets](https://deepeval.com/tutorials/doc-summarization-annotating-datasets): Learn to create and maintain datasets for document summarization.


### PR DESCRIPTION
DeepTeam's outbound links lag the tagging scheme deepeval already uses (utm_source/utm_medium/utm_content, runtime SOURCE = "deepteam"):

- **README**: two links carried a legacy `utm_source=GitHub` with no medium or content — indistinguishable from each other in analytics and inconsistent with the runtime schema. Both now carry the full triplet (`results_callout`, `platform_section`).
- **llms.txt**: both Confident AI links were untagged; now `utm_medium=llms_txt` so AI-assistant-driven arrivals are measurable as their own channel.

Not touched, flagged for maintainers: docs/public/llms.txt appears to be a copy of deepeval's — its description says "DeepEval is an open-source LLM evaluation framework…" rather than describing DeepTeam. Content rewrite felt out of scope for a tagging PR, but you probably want to reclaim that file. Also the CLI has no UTM helper (deepeval's cli/utils.py has with_utm) — happy to port it in a follow-up if wanted.

No content changes in this PR, parameters only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)