### PR TITLE
Add Atlas Cloud YAML provider support

### DIFF
--- a/deepteam/cli/model_callback.py
+++ b/deepteam/cli/model_callback.py
@@ -18,6 +18,10 @@ from deepeval.models import (
 )
 from deepeval.metrics.utils import initialize_model
 
+ATLASCLOUD_PROVIDER_ALIASES = {"atlas", "atlas-cloud", "atlascloud"}
+ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_DEFAULT_MODEL = "qwen/qwen3.5-flash"
+
 
 def _load_custom_model_from_file(
     file_path: str, class_name: str
@@ -48,6 +52,26 @@ def _load_custom_model_from_file(
     return model_class()
 
 
+def _get_atlascloud_api_key(spec: Dict[str, Any]) -> Optional[str]:
+    return (
+        spec.get("api_key")
+        or os.getenv("ATLASCLOUD_API_KEY")
+        or os.getenv("ATLAS_CLOUD_API_KEY")
+    )
+
+
+def _get_atlascloud_base_url(spec: Dict[str, Any]) -> str:
+    return (
+        spec.get("base_url")
+        or spec.get("baseURL")
+        or os.getenv("ATLASCLOUD_API_BASE")
+        or os.getenv("ATLASCLOUD_BASE_URL")
+        or os.getenv("ATLAS_CLOUD_API_BASE")
+        or os.getenv("ATLAS_CLOUD_BASE_URL")
+        or ATLASCLOUD_BASE_URL
+    )
+
+
 def load_model(spec: Union[str, Dict[str, Any], None]) -> DeepEvalBaseLLM:
     """Construct a DeepEval model instance from a YAML spec or string."""
     if spec is None or isinstance(spec, str):
@@ -61,6 +85,19 @@ def load_model(spec: Union[str, Dict[str, Any], None]) -> DeepEvalBaseLLM:
 
     if provider == "openai":
         return GPTModel(model=model_name, temperature=temperature)
+
+    if provider in ATLASCLOUD_PROVIDER_ALIASES:
+        return LocalModel(
+            model_name=(
+                model_name
+                or os.getenv("ATLASCLOUD_MODEL")
+                or os.getenv("ATLAS_CLOUD_MODEL")
+                or ATLASCLOUD_DEFAULT_MODEL
+            ),
+            base_url=_get_atlascloud_base_url(spec),
+            api_key=_get_atlascloud_api_key(spec),
+            temperature=temperature,
+        )
 
     if provider == "azure":
         return AzureOpenAIModel(

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -5,7 +5,7 @@
 models:
   simulator: gpt-3.5-turbo-0125
   evaluation: gpt-4o
-  
+
   # Alternative: With provider specification
   # simulator:
   #   provider: anthropic
@@ -15,18 +15,26 @@ models:
   #   provider: openai
   #   model: gpt-4o
   #   temperature: 0.1
+  # evaluation:
+  #   provider: atlascloud
+  #   model: qwen/qwen3.5-flash
+  #   temperature: 0.1
 
 # Target system configuration (uses custom model)
 target:
   purpose: "A helpful AI assistant"
-  
+
   # Option 1: Simple model specification (for testing foundational models directly)
   # model: gpt-3.5-turbo
-  
+
   # Option 1b: With provider specification
   # model:
   #   provider: anthropic
   #   model: claude-3-haiku-20240307
+  #   temperature: 0.5
+  # model:
+  #   provider: atlascloud
+  #   model: qwen/qwen3.5-flash
   #   temperature: 0.5
   
   # Option 2: Custom DeepEval model
@@ -73,4 +81,3 @@ attacks:
   
   - name: "Roleplay"
     weight: 0.9
-    

--- a/tests/test_core/test_yaml/test_atlascloud_model_callback.py
+++ b/tests/test_core/test_yaml/test_atlascloud_model_callback.py
@@ -1,0 +1,97 @@
+from deepteam.cli import model_callback
+
+
+class DummyLocalModel:
+    def __init__(
+        self,
+        model_name,
+        base_url=None,
+        api_key=None,
+        temperature=0,
+    ):
+        self.model_name = model_name
+        self.base_url = base_url
+        self.api_key = api_key
+        self.temperature = temperature
+
+
+def _patch_local_model(monkeypatch):
+    monkeypatch.setattr(model_callback, "LocalModel", DummyLocalModel)
+
+
+def _clear_atlascloud_env(monkeypatch):
+    for name in (
+        "ATLASCLOUD_API_KEY",
+        "ATLAS_CLOUD_API_KEY",
+        "ATLASCLOUD_API_BASE",
+        "ATLASCLOUD_BASE_URL",
+        "ATLAS_CLOUD_API_BASE",
+        "ATLAS_CLOUD_BASE_URL",
+        "ATLASCLOUD_MODEL",
+        "ATLAS_CLOUD_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_atlascloud_provider_uses_defaults(monkeypatch):
+    _patch_local_model(monkeypatch)
+    _clear_atlascloud_env(monkeypatch)
+
+    model = model_callback.load_model({"provider": "atlascloud"})
+
+    assert model.model_name == model_callback.ATLASCLOUD_DEFAULT_MODEL
+    assert model.base_url == model_callback.ATLASCLOUD_BASE_URL
+    assert model.api_key is None
+    assert model.temperature == 0
+
+
+def test_atlascloud_provider_reads_environment_fallbacks(monkeypatch):
+    _patch_local_model(monkeypatch)
+    _clear_atlascloud_env(monkeypatch)
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+    monkeypatch.setenv("ATLASCLOUD_API_BASE", "https://atlas.example/v1")
+    monkeypatch.setenv("ATLASCLOUD_MODEL", "deepseek-ai/deepseek-v4-pro")
+
+    model = model_callback.load_model(
+        {"provider": "atlas-cloud", "temperature": 0.2}
+    )
+
+    assert model.model_name == "deepseek-ai/deepseek-v4-pro"
+    assert model.base_url == "https://atlas.example/v1"
+    assert model.api_key == "env-key"
+    assert model.temperature == 0.2
+
+
+def test_atlascloud_explicit_config_takes_precedence(monkeypatch):
+    _patch_local_model(monkeypatch)
+    _clear_atlascloud_env(monkeypatch)
+    monkeypatch.setenv("ATLAS_CLOUD_API_KEY", "env-key")
+    monkeypatch.setenv("ATLAS_CLOUD_API_BASE", "https://env.example/v1")
+    monkeypatch.setenv("ATLAS_CLOUD_MODEL", "env/model")
+
+    model = model_callback.load_model(
+        {
+            "provider": "atlas",
+            "model": "explicit/model",
+            "base_url": "https://explicit.example/v1",
+            "api_key": "explicit-key",
+            "temperature": 0.7,
+        }
+    )
+
+    assert model.model_name == "explicit/model"
+    assert model.base_url == "https://explicit.example/v1"
+    assert model.api_key == "explicit-key"
+    assert model.temperature == 0.7
+
+
+def test_atlascloud_provider_aliases(monkeypatch):
+    _patch_local_model(monkeypatch)
+    _clear_atlascloud_env(monkeypatch)
+
+    for provider in ("atlas", "atlas-cloud", "atlascloud"):
+        model = model_callback.load_model(
+            {"provider": provider, "model": "qwen/qwen3.5-flash"}
+        )
+        assert model.model_name == "qwen/qwen3.5-flash"
+        assert model.base_url == model_callback.ATLASCLOUD_BASE_URL


### PR DESCRIPTION
## Summary
- Add `atlascloud`, `atlas-cloud`, and `atlas` provider aliases to the YAML model loader.
- Route Atlas Cloud through the existing OpenAI-compatible `LocalModel` path with default base URL `https://api.atlascloud.ai/v1` and default model `qwen/qwen3.5-flash`.
- Read Atlas Cloud credentials and overrides from `ATLASCLOUD_*` and `ATLAS_CLOUD_*` environment variables, while preserving explicit YAML config precedence.
- Add focused tests for defaults, environment fallback, explicit overrides, and provider aliases.

## Validation
- `.venv/bin/python -m pytest tests/test_core/test_yaml/test_atlascloud_model_callback.py -q` (`4 passed`)
- `.venv/bin/python -m pytest tests/test_core/test_yaml/test_yaml.py::test_target_loads_from_yaml_callback tests/test_core/test_yaml/test_yaml.py::test_models_loads_from_yaml_class -q` (`2 passed`)
- `.venv/bin/python -m black --check deepteam/cli/model_callback.py tests/test_core/test_yaml/test_atlascloud_model_callback.py`
- `PYTHONPYCACHEPREFIX=/tmp/deepteam-pyc .venv/bin/python -m compileall deepteam/cli/model_callback.py tests/test_core/test_yaml/test_atlascloud_model_callback.py`
- `git diff --check`
- Atlas Cloud catalog check returned 436 models and confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.

Note: the broader `tests/test_core/test_yaml/test_yaml.py` run still needs an `OPENAI_API_KEY` for the existing default OpenAI model construction in two tests; the non-OpenAI-key YAML tests above pass.

No README changes; the only example change is a small YAML provider snippet. No logo, sponsor, credits, or partner content was added.
